### PR TITLE
chore: replace @reach/router with react-router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
 				"@ethersproject/providers": "^5.6.8",
 				"@ethersproject/units": "^5.6.1",
 				"@ethersproject/wallet": "^5.6.2",
-				"@reach/router": "^1.3.4",
 				"@swarm-city/ui-library": "^0.2.0",
 				"classnames": "^2.3.1",
 				"ethers": "^5.6.9",
@@ -23,6 +22,8 @@
 				"react": "^18.2.0",
 				"react-dom": "^18.2.0",
 				"react-easy-crop": "^4.4.0",
+				"react-router": "^6.3.0",
+				"react-router-dom": "^6.3.0",
 				"teaful": "^0.10.0",
 				"wagmi": "^0.6.0"
 			},
@@ -1478,34 +1479,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
 			"integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
-		},
-		"node_modules/@reach/router": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
-			"integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-			"dependencies": {
-				"create-react-context": "0.3.0",
-				"invariant": "^2.2.3",
-				"prop-types": "^15.6.1",
-				"react-lifecycles-compat": "^3.0.4"
-			},
-			"peerDependencies": {
-				"react": "15.x || 16.x || 16.4.0-alpha.0911da3",
-				"react-dom": "15.x || 16.x || 16.4.0-alpha.0911da3"
-			}
-		},
-		"node_modules/@reach/router/node_modules/create-react-context": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-			"integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-			"dependencies": {
-				"gud": "^1.0.0",
-				"warning": "^4.0.3"
-			},
-			"peerDependencies": {
-				"prop-types": "^15.0.0",
-				"react": "^0.14.0 || ^15.0.0 || ^16.0.0"
-			}
 		},
 		"node_modules/@svgr/babel-plugin-add-jsx-attribute": {
 			"version": "5.4.0",
@@ -4988,11 +4961,6 @@
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
-		"node_modules/gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-		},
 		"node_modules/has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -5095,6 +5063,14 @@
 			"dependencies": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"node_modules/history": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+			"integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+			"dependencies": {
+				"@babel/runtime": "^7.7.6"
 			}
 		},
 		"node_modules/hmac-drbg": {
@@ -5231,14 +5207,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			}
-		},
-		"node_modules/invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dependencies": {
-				"loose-envify": "^1.0.0"
 			}
 		},
 		"node_modules/is-arguments": {
@@ -6249,6 +6217,7 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
 			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -6751,6 +6720,7 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
 			"dependencies": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -6962,12 +6932,8 @@
 		"node_modules/react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-		},
-		"node_modules/react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true
 		},
 		"node_modules/react-query": {
 			"version": "4.0.0-beta.23",
@@ -7003,6 +6969,30 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/react-router": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+			"integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+			"dependencies": {
+				"history": "^5.2.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8"
+			}
+		},
+		"node_modules/react-router-dom": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+			"integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+			"dependencies": {
+				"history": "^5.2.0",
+				"react-router": "6.3.0"
+			},
+			"peerDependencies": {
+				"react": ">=16.8",
+				"react-dom": ">=16.8"
 			}
 		},
 		"node_modules/readable-stream": {
@@ -8086,14 +8076,6 @@
 			"peerDependencies": {
 				"ethers": ">=5.5.1",
 				"react": ">=17.0.0"
-			}
-		},
-		"node_modules/warning": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-			"dependencies": {
-				"loose-envify": "^1.0.0"
 			}
 		},
 		"node_modules/webidl-conversions": {
@@ -9414,28 +9396,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/@pedrouid/environment/-/environment-1.0.1.tgz",
 			"integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
-		},
-		"@reach/router": {
-			"version": "1.3.4",
-			"resolved": "https://registry.npmjs.org/@reach/router/-/router-1.3.4.tgz",
-			"integrity": "sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==",
-			"requires": {
-				"create-react-context": "0.3.0",
-				"invariant": "^2.2.3",
-				"prop-types": "^15.6.1",
-				"react-lifecycles-compat": "^3.0.4"
-			},
-			"dependencies": {
-				"create-react-context": {
-					"version": "0.3.0",
-					"resolved": "https://registry.npmjs.org/create-react-context/-/create-react-context-0.3.0.tgz",
-					"integrity": "sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==",
-					"requires": {
-						"gud": "^1.0.0",
-						"warning": "^4.0.3"
-					}
-				}
-			}
 		},
 		"@svgr/babel-plugin-add-jsx-attribute": {
 			"version": "5.4.0",
@@ -11974,11 +11934,6 @@
 			"integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
 			"dev": true
 		},
-		"gud": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/gud/-/gud-1.0.0.tgz",
-			"integrity": "sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw=="
-		},
 		"has": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -12042,6 +11997,14 @@
 			"requires": {
 				"inherits": "^2.0.3",
 				"minimalistic-assert": "^1.0.1"
+			}
+		},
+		"history": {
+			"version": "5.3.0",
+			"resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+			"integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+			"requires": {
+				"@babel/runtime": "^7.7.6"
 			}
 		},
 		"hmac-drbg": {
@@ -12131,14 +12094,6 @@
 				"get-intrinsic": "^1.1.0",
 				"has": "^1.0.3",
 				"side-channel": "^1.0.4"
-			}
-		},
-		"invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"requires": {
-				"loose-envify": "^1.0.0"
 			}
 		},
 		"is-arguments": {
@@ -12870,7 +12825,8 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
+			"integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+			"dev": true
 		},
 		"object-inspect": {
 			"version": "1.12.2",
@@ -13211,6 +13167,7 @@
 			"version": "15.8.1",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
 			"integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -13355,12 +13312,8 @@
 		"react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
-		},
-		"react-lifecycles-compat": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
-			"integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+			"dev": true
 		},
 		"react-query": {
 			"version": "4.0.0-beta.23",
@@ -13379,6 +13332,23 @@
 			"resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
 			"integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
 			"dev": true
+		},
+		"react-router": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
+			"integrity": "sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==",
+			"requires": {
+				"history": "^5.2.0"
+			}
+		},
+		"react-router-dom": {
+			"version": "6.3.0",
+			"resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.3.0.tgz",
+			"integrity": "sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==",
+			"requires": {
+				"history": "^5.2.0",
+				"react-router": "6.3.0"
+			}
 		},
 		"readable-stream": {
 			"version": "3.6.0",
@@ -14158,14 +14128,6 @@
 				"@walletconnect/ethereum-provider": "^1.7.8",
 				"react-query": "4.0.0-beta.23",
 				"use-sync-external-store": "^1.2.0"
-			}
-		},
-		"warning": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
-			"integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
-			"requires": {
-				"loose-envify": "^1.0.0"
 			}
 		},
 		"webidl-conversions": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
 		"@ethersproject/providers": "^5.6.8",
 		"@ethersproject/units": "^5.6.1",
 		"@ethersproject/wallet": "^5.6.2",
-		"@reach/router": "^1.3.4",
 		"@swarm-city/ui-library": "^0.2.0",
 		"classnames": "^2.3.1",
 		"ethers": "^5.6.9",
@@ -25,6 +24,8 @@
 		"react": "^18.2.0",
 		"react-dom": "^18.2.0",
 		"react-easy-crop": "^4.4.0",
+		"react-router": "^6.3.0",
+		"react-router-dom": "^6.3.0",
 		"teaful": "^0.10.0",
 		"wagmi": "^0.6.0"
 	},

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { Router } from '@reach/router'
+import { Routes, Route } from 'react-router-dom'
 import { WagmiConfig, createClient, configureChains, Chain } from 'wagmi'
 import { jsonRpcProvider } from 'wagmi/providers/jsonRpc'
 
@@ -92,18 +92,24 @@ export const App = () => {
 	return (
 		<WagmiConfig client={client}>
 			<PasswordSigner ref={ref} />
-			<Router>
-				<Login path={ROUTES.LOGIN} />
-				<SetupProfile path={ROUTES.CREATE_ACCOUNT} />
-				<AccountCreated path={ROUTES.ACCOUNT_CREATED} />
-				<ChoosePassword path={ROUTES.ACCOUNT_PASSWORD} />
-				<Backup path={ROUTES.ACCOUNT_BACKUP} />
-				<Account path={ROUTES.ACCOUNT} />
-				<AccountRestore path={ROUTES.ACCOUNT_RESTORE} />
-				<Home path={ROUTES.HOME} />
-				<AccountWallet path={`${ROUTES.ACCOUNT_WALLET}/*`} />
-				<AccountPublicWallet path={ROUTES.ACCOUNT_PUBLIC_WALLET} />
-			</Router>
+			<Routes>
+				<Route element={<Login />} path={ROUTES.LOGIN} />
+				<Route element={<SetupProfile />} path={ROUTES.CREATE_ACCOUNT} />
+				<Route element={<AccountCreated />} path={ROUTES.ACCOUNT_CREATED} />
+				<Route element={<ChoosePassword />} path={ROUTES.ACCOUNT_PASSWORD} />
+				<Route element={<Backup />} path={ROUTES.ACCOUNT_BACKUP} />
+				<Route element={<Account />} path={ROUTES.ACCOUNT} />
+				<Route element={<AccountRestore />} path={ROUTES.ACCOUNT_RESTORE} />
+				<Route element={<Home />} path={ROUTES.HOME} />
+				<Route
+					element={<AccountWallet />}
+					path={`${ROUTES.ACCOUNT_WALLET}/*`}
+				/>
+				<Route
+					element={<AccountPublicWallet />}
+					path={ROUTES.ACCOUNT_PUBLIC_WALLET}
+				/>
+			</Routes>
 		</WagmiConfig>
 	)
 }

--- a/src/components/ButtonClose.tsx
+++ b/src/components/ButtonClose.tsx
@@ -12,14 +12,11 @@ const VARIANTS = {
 	dark: close,
 }
 
-export interface ButtonCloseProps<TState> extends FlexLinkProps<TState> {
+export interface ButtonCloseProps extends FlexLinkProps {
 	variant?: keyof typeof VARIANTS
 }
 
-export function ButtonClose<TState>({
-	variant,
-	...other
-}: ButtonCloseProps<TState>) {
+export function ButtonClose({ variant, ...other }: ButtonCloseProps) {
 	return (
 		<FlexLink role="button" {...other}>
 			<img src={VARIANTS[variant || 'default']} />

--- a/src/components/ButtonRoundArrow.tsx
+++ b/src/components/ButtonRoundArrow.tsx
@@ -25,18 +25,18 @@ const VARIANTS = {
 	green: caretNextGreen,
 }
 
-export interface ButtonRoundArrowProps<TState> extends FlexLinkProps<TState> {
+export interface ButtonRoundArrowProps extends FlexLinkProps {
 	disabled?: boolean
 	direction?: keyof typeof DIRECTIONS
 	variant?: keyof typeof VARIANTS
 }
 
-export function ButtonRoundArrow<TState>({
+export function ButtonRoundArrow({
 	disabled,
 	direction,
 	variant,
 	...other
-}: ButtonRoundArrowProps<TState>) {
+}: ButtonRoundArrowProps) {
 	const classes = cn('btn-icon', variant === 'negative' && 'btn-neg')
 	const rotation = DIRECTIONS[direction || 'right']
 	const img = (

--- a/src/components/FlexLink.tsx
+++ b/src/components/FlexLink.tsx
@@ -1,20 +1,16 @@
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 
 // Types
-import type { LinkProps } from '@reach/router'
+import type { LinkProps } from 'react-router-dom'
 import type { AnchorHTMLAttributes } from 'react'
 
-export interface FlexLinkProps<TState>
-	extends Omit<LinkProps<TState>, 'ref' | 'to' | 'onClick'>,
+export interface FlexLinkProps
+	extends Omit<LinkProps, 'ref' | 'to' | 'onClick'>,
 		Pick<AnchorHTMLAttributes<HTMLAnchorElement>, 'href' | 'onClick'> {
-	to?: LinkProps<TState>['to']
+	to?: LinkProps['to']
 }
 
-export function FlexLink<TState>({
-	href,
-	to,
-	...other
-}: FlexLinkProps<TState>) {
+export function FlexLink({ href, to, ...other }: FlexLinkProps) {
 	if (to && href) {
 		console.warn('do not specify both `to` and `href`')
 		return null

--- a/src/components/modals/confirm-modal/confirm-modal.tsx
+++ b/src/components/modals/confirm-modal/confirm-modal.tsx
@@ -12,9 +12,9 @@ import type { ReactNode } from 'react'
 // Style
 import classes from './confirm-modal.module.css'
 
-export type ConfirmModalProps<CancelState, ConfirmState> = {
-	cancel?: ButtonCloseProps<CancelState>
-	confirm?: ButtonRoundArrowProps<ConfirmState>
+export type ConfirmModalProps = {
+	cancel?: ButtonCloseProps
+	confirm?: ButtonRoundArrowProps
 	color?:
 		| 'primary'
 		| 'secondary'
@@ -29,12 +29,12 @@ export type ConfirmModalProps<CancelState, ConfirmState> = {
 	children: ReactNode
 }
 
-export const ConfirmModal = <CancelState, ConfirmState>({
+export const ConfirmModal = ({
 	cancel,
 	confirm,
 	color,
 	children,
-}: ConfirmModalProps<CancelState, ConfirmState>) => {
+}: ConfirmModalProps) => {
 	return (
 		<div
 			className={cn(classes.confirmModal, color ? `bg-${color}` : 'bg-info')}

--- a/src/components/modals/user-create-stop.tsx
+++ b/src/components/modals/user-create-stop.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 
 // Components
 import { ButtonClose } from '../ButtonClose'

--- a/src/components/redirect.tsx
+++ b/src/components/redirect.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+type RedirectProps = {
+	to: string
+}
+
+export const Redirect = ({ to }: RedirectProps) => {
+	const navigate = useNavigate()
+	useEffect(() => {
+		navigate(to)
+	})
+	return null
+}

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -7562,7 +7562,7 @@ body {
 body #app {
 	height: 100% !important;
 }
-body #app > div > div {
+body #app > div {
 	padding-top: 137px;
 	padding-bottom: 60px;
 	min-height: 100vh;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,7 +1,12 @@
 import { createRoot } from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import { App } from './app'
 import './css/style.css'
 import './css/custom.css'
 
 // NOTE: Strict mode breaks reach router, so it was removed for now
-createRoot(document.getElementById('app') as HTMLElement).render(<App />)
+createRoot(document.getElementById('app') as HTMLElement).render(
+	<BrowserRouter>
+		<App />
+	</BrowserRouter>
+)

--- a/src/pages/account-restore.tsx
+++ b/src/pages/account-restore.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 import { useState } from 'react'
 
 // Assets
@@ -15,12 +15,9 @@ import { UserCreateStop } from '../components/modals/user-create-stop'
 
 // Types
 import type { Profile } from '../types/profile'
-import type { RouteComponentProps } from '@reach/router'
 import type { ChangeEvent } from 'react'
 
-type Props = RouteComponentProps
-
-export const AccountRestore = (_: Props) => {
+export const AccountRestore = () => {
 	const [profile, setProfile] = useStore.profile()
 	const [restoredProfile, setRestoredProfile] = useState<Profile | null>(null)
 	const [confirmed, setConfirmed] = useState(false)

--- a/src/pages/account.tsx
+++ b/src/pages/account.tsx
@@ -1,9 +1,12 @@
 import { useAccount, useBalance, useNetwork } from 'wagmi'
-import { Link, Redirect } from '@reach/router'
+import { Link } from 'react-router-dom'
 
 // Routes and store
 import { ACCOUNT_WALLET, LOGIN } from '../routes'
 import { useStore } from '../store'
+
+// Components
+import { Redirect } from '../components/redirect'
 
 // Lib
 import { formatBalance } from '../lib/tools'
@@ -12,12 +15,7 @@ import { formatBalance } from '../lib/tools'
 import avatarDefault from '../assets/imgs/avatar.svg?url'
 import exit from '../assets/imgs/exit.svg?url'
 
-// Types
-import type { RouteComponentProps } from '@reach/router'
-
-type Props = RouteComponentProps
-
-export const Account = (_: Props) => {
+export const Account = () => {
 	const [profile, setProfile] = useStore.profile()
 
 	const { chain } = useNetwork()
@@ -30,7 +28,7 @@ export const Account = (_: Props) => {
 	})
 
 	if (!profile?.address) {
-		return <Redirect to={LOGIN} noThrow />
+		return <Redirect to={LOGIN} />
 	}
 
 	return (

--- a/src/pages/create-account/backup.tsx
+++ b/src/pages/create-account/backup.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from 'react'
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 
 // Components
 import { UserCreateStop } from '../../components/modals/user-create-stop'
@@ -12,12 +12,7 @@ import warningBlue from '../../assets/imgs/warningBlue.svg?url'
 import { ACCOUNT } from '../../routes'
 import { useStore } from '../../store'
 
-// Types
-import type { RouteComponentProps } from '@reach/router'
-
-type Props = RouteComponentProps
-
-export const Backup = (_: Props) => {
+export const Backup = () => {
 	const [showPrompt, setShowPrompt] = useState(true)
 	const [profile] = useStore.profile()
 	const blob = useMemo(

--- a/src/pages/create-account/choose-password.tsx
+++ b/src/pages/create-account/choose-password.tsx
@@ -1,21 +1,20 @@
 import { useState } from 'react'
 import warningBlue from '../../assets/imgs/warningBlue.svg?url'
 import { ACCOUNT_CREATED } from '../../routes'
-import { navigate, RouteComponentProps } from '@reach/router'
+import { useNavigate } from 'react-router-dom'
 import { Wallet } from 'ethers'
 import { UserCreateStop } from '../../components/modals/user-create-stop'
 import { ButtonRoundArrow } from '../../components/ButtonRoundArrow'
 import { useStore } from '../../store'
 import { Input } from '../../components/input/input'
 
-type Props = RouteComponentProps
-
-export const ChoosePassword = (_: Props) => {
+export const ChoosePassword = () => {
 	const [showPrompt, setShowPrompt] = useState(true)
 	const [profile, setProfile] = useStore.profile()
 	const [loading, setLoading] = useState(false)
 	const [password, setPassword] = useState<string>('')
 	const [password2, setPassword2] = useState<string>('')
+	const navigate = useNavigate()
 
 	const onClick = () => {
 		setLoading(true)

--- a/src/pages/create-account/created.tsx
+++ b/src/pages/create-account/created.tsx
@@ -1,5 +1,5 @@
 // Store
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 
 // Store and routes
 import { useStore } from '../../store'
@@ -11,10 +11,7 @@ import { UserCreateStop } from '../../components/modals/user-create-stop'
 // Assets
 import avatarDefault from '../../assets/imgs/avatar.svg?url'
 
-// Types
-import type { RouteComponentProps } from '@reach/router'
-
-export const AccountCreated = (_: RouteComponentProps) => {
+export const AccountCreated = () => {
 	const [profile] = useStore.profile()
 
 	if (!profile) {

--- a/src/pages/create-account/setup-profile.tsx
+++ b/src/pages/create-account/setup-profile.tsx
@@ -1,4 +1,4 @@
-import { navigate } from '@reach/router'
+import { useNavigate } from 'react-router-dom'
 
 // Store and routes
 import { useStore } from '../../store'
@@ -14,13 +14,11 @@ import { UserCreateStop } from '../../components/modals/user-create-stop'
 import { CreateAvatar } from '../../components/modals/create-avatar'
 
 // Types
-import type { RouteComponentProps } from '@reach/router'
 import type { FormEvent } from 'react'
 
-type Props = RouteComponentProps
-
-export const SetupProfile = (_: Props) => {
+export const SetupProfile = () => {
 	const [profile, setProfile] = useStore.profile()
+	const navigate = useNavigate()
 	const onSubmit = (event: FormEvent<HTMLFormElement>) => {
 		event.preventDefault()
 		navigate(ACCOUNT_PASSWORD)

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -1,4 +1,4 @@
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 
 // Store and routes
 import { ACCOUNT, LOGIN } from '../routes'
@@ -7,12 +7,7 @@ import { useStore } from '../store'
 // Assets
 import logo from '../assets/imgs/logo.svg?url'
 
-// Types
-import type { RouteComponentProps } from '@reach/router'
-
-type HomeProps = RouteComponentProps
-
-export const Home = (_: HomeProps) => {
+export const Home = () => {
 	const [profile] = useStore.profile()
 	const hasProfile = profile?.encryptedWallet
 

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,16 +1,14 @@
-import { Link, RouteComponentProps } from '@reach/router'
+import { Link } from 'react-router-dom'
 import { ButtonClose } from '../components/ButtonClose'
 import { ACCOUNT_RESTORE, CREATE_ACCOUNT, HOME } from '../routes'
 
-type LoginProps = RouteComponentProps
-
-export const Login = (_: LoginProps) => (
+export const Login = () => (
 	<div className="bg-info create-account">
 		<div className="close">
 			<ButtonClose to={HOME} variant="light" />
 		</div>
 		<div className="container">
-			<main className=" flex-space">
+			<main className="flex-space">
 				<header>
 					<h1>Let's create an account.</h1>
 					<p>

--- a/src/pages/user-wallet/public.tsx
+++ b/src/pages/user-wallet/public.tsx
@@ -1,29 +1,24 @@
 import { useState } from 'react'
-import { Redirect } from '@reach/router'
 import { QRCodeSVG } from 'qrcode.react'
 
 // Components
 import { ButtonClose } from '../../components/ButtonClose'
 import { PasswordModal } from '../../components/modals/password/password'
 import { CopyLink } from '../../components/copy-link/copy-link'
+import { Redirect } from '../../components/redirect'
 
 // Store and routes
 import { useStore } from '../../store'
 import { LOGIN, ACCOUNT_WALLET } from '../../routes'
 
-// Types
-import type { RouteComponentProps } from '@reach/router'
-
-type AccountPublicWalletProps = RouteComponentProps
-
-export const AccountPublicWallet = (_: AccountPublicWalletProps) => {
+export const AccountPublicWallet = () => {
 	const [showQR, setShowQR] = useState(false)
 	const [showPassword, setShowPassword] = useState(false)
 	const [privateKey, setPrivateKey] = useState<string>()
 	const [profile] = useStore.profile()
 
 	if (!profile?.address) {
-		return <Redirect to={LOGIN} noThrow />
+		return <Redirect to={LOGIN} />
 	}
 
 	return (

--- a/src/pages/user-wallet/wallet.tsx
+++ b/src/pages/user-wallet/wallet.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Link, navigate, Redirect, Router } from '@reach/router'
+import { Link, useNavigate, Routes, Route } from 'react-router-dom'
 import {
 	useAccount,
 	useBalance,
@@ -16,6 +16,7 @@ import { Input } from '../../components/input/input'
 import { ButtonRoundArrow } from '../../components/ButtonRoundArrow'
 import { ConfirmModal } from '../../components/modals/confirm-modal/confirm-modal'
 import { FullscreenLoading } from '../../components/modals/fullscreen-loading/fullscreen-loading'
+import { Redirect } from '../../components/redirect'
 
 // Lib
 import { formatAddressShort, formatBalance } from '../../lib/tools'
@@ -30,10 +31,7 @@ import {
 	ACCOUNT_WALLET,
 } from '../../routes'
 
-// Types
-import type { RouteComponentProps } from '@reach/router'
-
-const Menu = (_: RouteComponentProps) => {
+const Menu = () => {
 	const { chain } = useNetwork()
 	const symbol = chain?.nativeCurrency?.symbol
 
@@ -69,7 +67,7 @@ const formatRequest = ({
 	return { to, value, isValid }
 }
 
-const Send = (_: RouteComponentProps) => {
+const Send = () => {
 	const [showConfirm, setShowConfirm] = useState(false)
 	const [amount, setAmount] = useState('0')
 	const [address, setAddress] = useState('')
@@ -82,6 +80,7 @@ const Send = (_: RouteComponentProps) => {
 	const { isLoading, isError, isSuccess, error, sendTransaction, reset } =
 		useSendTransaction(config)
 
+	const navigate = useNavigate()
 	const submit = () => setShowConfirm(isValid)
 
 	if (isLoading) {
@@ -173,7 +172,7 @@ const Send = (_: RouteComponentProps) => {
 	)
 }
 
-export const AccountWallet = (_: RouteComponentProps) => {
+export const AccountWallet = () => {
 	const [profile] = useStore.profile()
 
 	const { chain } = useNetwork()
@@ -186,7 +185,7 @@ export const AccountWallet = (_: RouteComponentProps) => {
 	})
 
 	if (!profile?.address) {
-		return <Redirect to={LOGIN} noThrow />
+		return <Redirect to={LOGIN} />
 	}
 
 	return (
@@ -217,10 +216,10 @@ export const AccountWallet = (_: RouteComponentProps) => {
 			</div>
 			<div className="divider short" />
 			<div className="container">
-				<Router>
-					<Send path="/send" />
-					<Menu default />
-				</Router>
+				<Routes>
+					<Route element={<Send />} path="/send" />
+					<Route element={<Menu />} path="*" />
+				</Routes>
 			</div>
 		</div>
 	)


### PR DESCRIPTION
Reach router actually hasn't been updated for more than two years now, and the recommended upgrade path is to React Router 6, as per https://reach.tech/router/. It's also not officially compatible with React 18.