### PR TITLE
fix: issues with duplicate metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
 				{
 					"case": "kebabCase"
 				}
-			]
+			],
+			"prefer-reflect": "off"
 		},
 		"settings": {
 			"react": {


### PR DESCRIPTION
Currently, there are two issues:

- If multiple on-chain items have the same metadata, only one will be displayed
- If there are multiple copies of on message in Waku, it might display the same item twice

This PR fixes both of these issues. One slight disadvantage, is that old on chain items might resurface if they have identical metadata than a more recent item.