### PR TITLE
feat: add hooks to fetch reputation

### DIFF
--- a/src/pages/marketplaces/services/marketplace.ts
+++ b/src/pages/marketplaces/services/marketplace.ts
@@ -12,6 +12,7 @@ import { cleanOutput } from '../../../lib/ethers'
 
 // Services
 import { Status } from './marketplace-items'
+import { useReputation } from '../../../services/reputation'
 
 // Types
 export type MarketplaceItem = {
@@ -155,6 +156,22 @@ export const useMarketplaceItem = (marketplace: string, itemId: bigint) => {
 	}, [marketplace, itemId])
 
 	return { item, lastUpdate, loading }
+}
+
+export const useMarketplaceSeekerReputation = (
+	marketplace: string,
+	user: string
+) => {
+	const config = useMarketplaceConfig(marketplace, ['seekerRep'])
+	return useReputation(config?.seekerRep, user)
+}
+
+export const useMarketplaceProviderReputation = (
+	marketplace: string,
+	user: string
+) => {
+	const config = useMarketplaceConfig(marketplace, ['providerRep'])
+	return useReputation(config?.providerRep, user)
 }
 
 // TODO: Replace this with a public function once new contracts are deployed

--- a/src/services/reputation.tsx
+++ b/src/services/reputation.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useMemo, useState } from 'react'
+import { Contract } from 'ethers'
+import { useProvider } from 'wagmi'
+
+// Types
+import type { BigNumberish } from 'ethers'
+
+// ABIs
+import erc20Abi from '../abis/erc20.json'
+
+export const useReputationContract = (contract?: string) => {
+	const provider = useProvider()
+	return useMemo(
+		() => contract && new Contract(contract, erc20Abi, provider),
+		[contract]
+	)
+}
+
+export const useReputation = (token: string | undefined, user: string) => {
+	const contract = useReputationContract(token)
+	const [balance, setBalance] = useState<BigNumberish>()
+
+	useEffect(() => {
+		if (!contract) {
+			return
+		}
+
+		contract.balanceOf(user).then(setBalance)
+	}, [contract])
+
+	return balance
+}


### PR DESCRIPTION
This allows us to fetch reputations, but there's no real optimized way to do so for the profile page where reputations of all marketplaces are displayed.

A strategy that would fetch events in one go would not be efficient in this case, so I guess for now our only option is to fetch the addresses of each marketplace and show their respective reputations. Then we can hide the marketplaces where both reputations are 0.

In the future, we might want to add a function in the marketplace contract that fetches both the seeker and provider reputations in one go, which would save 2 contract calls from the user interface.