### PR TITLE
chore: remove `vite-plugin-react-svg`

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -45,7 +45,7 @@ jobs:
           node-version: 16
 
       - name: Install npm deps
-        run: npm ci -f
+        run: npm ci
 
       - name: Build for gh-pages
         run: |

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install npm deps
         if: steps.cache-npm.outputs.cache-hit != 'true'
-        run: npm ci --force
+        run: npm ci
 
       - name: Build
         run: npm run build

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install npm deps
         if: steps.cache-npm.outputs.cache-hit != 'true'
-        run: npm ci --force
+        run: npm ci
 
       - name: Run linting test
         run: npm run lint

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,8 +50,7 @@
 				"protons": "^5.1.0",
 				"puppeteer": "^16.0.0",
 				"typescript": "^4.7.4",
-				"vite": "^3.0.4",
-				"vite-plugin-react-svg": "^0.2.0"
+				"vite": "^3.0.4"
 			},
 			"engines": {
 				"node": ">=16.0.0"
@@ -2643,191 +2642,6 @@
 				"@stablelib/wipe": "^1.0.1"
 			}
 		},
-		"node_modules/@svgr/babel-plugin-add-jsx-attribute": {
-			"version": "5.4.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-remove-jsx-attribute": {
-			"version": "5.4.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-remove-jsx-empty-expression": {
-			"version": "5.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-replace-jsx-attribute-value": {
-			"version": "5.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-svg-dynamic-title": {
-			"version": "5.4.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-svg-em-dimensions": {
-			"version": "5.4.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-transform-react-native-svg": {
-			"version": "5.4.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-plugin-transform-svg-component": {
-			"version": "5.5.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/babel-preset": {
-			"version": "5.5.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
-				"@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
-				"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
-				"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
-				"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
-				"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
-				"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
-				"@svgr/babel-plugin-transform-svg-component": "^5.5.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/core": {
-			"version": "5.5.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@svgr/plugin-jsx": "^5.5.0",
-				"camelcase": "^6.2.0",
-				"cosmiconfig": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/hast-util-to-babel-ast": {
-			"version": "5.5.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/types": "^7.12.6"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/plugin-jsx": {
-			"version": "5.5.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/core": "^7.12.3",
-				"@svgr/babel-preset": "^5.5.0",
-				"@svgr/hast-util-to-babel-ast": "^5.5.0",
-				"svg-parser": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
-		"node_modules/@svgr/plugin-svgo": {
-			"version": "5.5.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"cosmiconfig": "^7.0.0",
-				"deepmerge": "^4.2.2",
-				"svgo": "^1.2.2"
-			},
-			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/gregberge"
-			}
-		},
 		"node_modules/@swarm-city/ui-library": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@swarm-city/ui-library/-/ui-library-0.3.0.tgz",
@@ -2890,11 +2704,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@types/parse-json": {
-			"version": "4.0.0",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@types/pbkdf2": {
 			"version": "3.1.0",
 			"license": "MIT",
@@ -2904,11 +2713,6 @@
 		},
 		"node_modules/@types/prop-types": {
 			"version": "15.7.5",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@types/q": {
-			"version": "1.5.5",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -3571,24 +3375,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/array.prototype.reduce": {
-			"version": "1.0.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.2",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -3769,11 +3555,6 @@
 		"node_modules/bn.js": {
 			"version": "5.2.1",
 			"license": "MIT"
-		},
-		"node_modules/boolbase": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "ISC"
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
@@ -4198,19 +3979,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/coa": {
-			"version": "2.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/q": "^1.5.1",
-				"chalk": "^2.4.1",
-				"q": "^1.1.2"
-			},
-			"engines": {
-				"node": ">= 4.0"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "1.9.3",
 			"license": "MIT",
@@ -4272,29 +4040,6 @@
 				"semver": "bin/semver.js"
 			}
 		},
-		"node_modules/cosmiconfig": {
-			"version": "7.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"engines": {
-				"node": ">=10"
-			}
-		},
-		"node_modules/cosmiconfig/node_modules/yaml": {
-			"version": "1.10.2",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">= 6"
-			}
-		},
 		"node_modules/create-hash": {
 			"version": "1.2.0",
 			"license": "MIT",
@@ -4336,73 +4081,6 @@
 			"engines": {
 				"node": ">= 8"
 			}
-		},
-		"node_modules/css-select": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"boolbase": "^1.0.0",
-				"css-what": "^3.2.1",
-				"domutils": "^1.7.0",
-				"nth-check": "^1.0.2"
-			}
-		},
-		"node_modules/css-select-base-adapter": {
-			"version": "0.1.1",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/css-tree": {
-			"version": "1.0.0-alpha.37",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.0.4",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/css-what": {
-			"version": "3.4.2",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"engines": {
-				"node": ">= 6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/fb55"
-			}
-		},
-		"node_modules/csso": {
-			"version": "4.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"css-tree": "^1.1.2"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/csso/node_modules/css-tree": {
-			"version": "1.1.3",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"mdn-data": "2.0.14",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/csso/node_modules/mdn-data": {
-			"version": "2.0.14",
-			"dev": true,
-			"license": "CC0-1.0"
 		},
 		"node_modules/csstype": {
 			"version": "3.1.0",
@@ -4487,14 +4165,6 @@
 			"version": "0.1.4",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/deepmerge": {
-			"version": "4.2.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/default-gateway": {
 			"version": "6.0.3",
@@ -4679,40 +4349,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/dom-serializer": {
-			"version": "0.2.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"domelementtype": "^2.0.1",
-				"entities": "^2.0.0"
-			}
-		},
-		"node_modules/dom-serializer/node_modules/domelementtype": {
-			"version": "2.3.0",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fb55"
-				}
-			],
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/domelementtype": {
-			"version": "1.3.1",
-			"dev": true,
-			"license": "BSD-2-Clause"
-		},
-		"node_modules/domutils": {
-			"version": "1.7.0",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
 		"node_modules/eastasianwidth": {
 			"version": "0.2.0",
 			"dev": true,
@@ -4768,14 +4404,6 @@
 				"once": "^1.4.0"
 			}
 		},
-		"node_modules/entities": {
-			"version": "2.2.0",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"funding": {
-				"url": "https://github.com/fb55/entities?sponsor=1"
-			}
-		},
 		"node_modules/err-code": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
@@ -4823,11 +4451,6 @@
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
 			}
-		},
-		"node_modules/es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/es-shim-unscopables": {
 			"version": "1.0.0",
@@ -7725,11 +7348,6 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
-		"node_modules/mdn-data": {
-			"version": "2.0.4",
-			"dev": true,
-			"license": "CC0-1.0"
-		},
 		"node_modules/mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -7961,17 +7579,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/mkdirp": {
-			"version": "0.5.6",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"minimist": "^1.2.6"
-			},
-			"bin": {
-				"mkdirp": "bin/cmd.js"
-			}
-		},
 		"node_modules/mkdirp-classic": {
 			"version": "0.5.3",
 			"dev": true,
@@ -8181,14 +7788,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/nth-check": {
-			"version": "1.0.2",
-			"dev": true,
-			"license": "BSD-2-Clause",
-			"dependencies": {
-				"boolbase": "~1.0.0"
-			}
-		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"dev": true,
@@ -8251,23 +7850,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/object.getownpropertydescriptors": {
-			"version": "2.1.4",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"array.prototype.reduce": "^1.0.4",
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.1"
-			},
-			"engines": {
-				"node": ">= 0.8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -9184,15 +8766,6 @@
 				}
 			}
 		},
-		"node_modules/q": {
-			"version": "1.5.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.6.0",
-				"teleport": ">=0.2.0"
-			}
-		},
 		"node_modules/qrcode": {
 			"version": "1.4.4",
 			"license": "MIT",
@@ -9937,6 +9510,7 @@
 			"version": "0.6.1",
 			"dev": true,
 			"license": "BSD-3-Clause",
+			"optional": true,
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9988,16 +9562,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/sprintf-js": {
-			"version": "1.0.3",
-			"dev": true,
-			"license": "BSD-3-Clause"
-		},
-		"node_modules/stable": {
-			"version": "0.1.8",
-			"dev": true,
-			"license": "MIT"
 		},
 		"node_modules/stream-browserify": {
 			"version": "3.0.0",
@@ -10203,57 +9767,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/svg-parser": {
-			"version": "2.0.4",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/svgo": {
-			"version": "1.3.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^2.4.1",
-				"coa": "^2.0.2",
-				"css-select": "^2.0.0",
-				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.37",
-				"csso": "^4.0.2",
-				"js-yaml": "^3.13.1",
-				"mkdirp": "~0.5.1",
-				"object.values": "^1.1.0",
-				"sax": "~1.2.4",
-				"stable": "^0.1.8",
-				"unquote": "~1.1.1",
-				"util.promisify": "~1.0.0"
-			},
-			"bin": {
-				"svgo": "bin/svgo"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
-		"node_modules/svgo/node_modules/argparse": {
-			"version": "1.0.10",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"sprintf-js": "~1.0.2"
-			}
-		},
-		"node_modules/svgo/node_modules/js-yaml": {
-			"version": "3.14.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"argparse": "^1.0.7",
-				"esprima": "^4.0.0"
-			},
-			"bin": {
-				"js-yaml": "bin/js-yaml.js"
 			}
 		},
 		"node_modules/taffydb": {
@@ -10538,11 +10051,6 @@
 				"detect-node": "^2.0.4"
 			}
 		},
-		"node_modules/unquote": {
-			"version": "1.1.1",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/update-browserslist-db": {
 			"version": "1.0.5",
 			"funding": [
@@ -10623,20 +10131,6 @@
 			"version": "1.0.2",
 			"license": "MIT"
 		},
-		"node_modules/util.promisify": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
 			"license": "MIT",
@@ -10701,20 +10195,6 @@
 				"terser": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/vite-plugin-react-svg": {
-			"version": "0.2.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/plugin-transform-react-jsx": "^7.12.12",
-				"@svgr/core": "^5.5.0",
-				"@svgr/plugin-jsx": "^5.5.0",
-				"@svgr/plugin-svgo": "^5.5.0"
-			},
-			"peerDependencies": {
-				"vite": "^2.0.0-beta.61"
 			}
 		},
 		"node_modules/vite/node_modules/resolve": {
@@ -12928,87 +12408,6 @@
 				"@stablelib/wipe": "^1.0.1"
 			}
 		},
-		"@svgr/babel-plugin-add-jsx-attribute": {
-			"version": "5.4.0",
-			"dev": true
-		},
-		"@svgr/babel-plugin-remove-jsx-attribute": {
-			"version": "5.4.0",
-			"dev": true
-		},
-		"@svgr/babel-plugin-remove-jsx-empty-expression": {
-			"version": "5.0.1",
-			"dev": true
-		},
-		"@svgr/babel-plugin-replace-jsx-attribute-value": {
-			"version": "5.0.1",
-			"dev": true
-		},
-		"@svgr/babel-plugin-svg-dynamic-title": {
-			"version": "5.4.0",
-			"dev": true
-		},
-		"@svgr/babel-plugin-svg-em-dimensions": {
-			"version": "5.4.0",
-			"dev": true
-		},
-		"@svgr/babel-plugin-transform-react-native-svg": {
-			"version": "5.4.0",
-			"dev": true
-		},
-		"@svgr/babel-plugin-transform-svg-component": {
-			"version": "5.5.0",
-			"dev": true
-		},
-		"@svgr/babel-preset": {
-			"version": "5.5.0",
-			"dev": true,
-			"requires": {
-				"@svgr/babel-plugin-add-jsx-attribute": "^5.4.0",
-				"@svgr/babel-plugin-remove-jsx-attribute": "^5.4.0",
-				"@svgr/babel-plugin-remove-jsx-empty-expression": "^5.0.1",
-				"@svgr/babel-plugin-replace-jsx-attribute-value": "^5.0.1",
-				"@svgr/babel-plugin-svg-dynamic-title": "^5.4.0",
-				"@svgr/babel-plugin-svg-em-dimensions": "^5.4.0",
-				"@svgr/babel-plugin-transform-react-native-svg": "^5.4.0",
-				"@svgr/babel-plugin-transform-svg-component": "^5.5.0"
-			}
-		},
-		"@svgr/core": {
-			"version": "5.5.0",
-			"dev": true,
-			"requires": {
-				"@svgr/plugin-jsx": "^5.5.0",
-				"camelcase": "^6.2.0",
-				"cosmiconfig": "^7.0.0"
-			}
-		},
-		"@svgr/hast-util-to-babel-ast": {
-			"version": "5.5.0",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.12.6"
-			}
-		},
-		"@svgr/plugin-jsx": {
-			"version": "5.5.0",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.12.3",
-				"@svgr/babel-preset": "^5.5.0",
-				"@svgr/hast-util-to-babel-ast": "^5.5.0",
-				"svg-parser": "^2.0.2"
-			}
-		},
-		"@svgr/plugin-svgo": {
-			"version": "5.5.0",
-			"dev": true,
-			"requires": {
-				"cosmiconfig": "^7.0.0",
-				"deepmerge": "^4.2.2",
-				"svgo": "^1.2.2"
-			}
-		},
 		"@swarm-city/ui-library": {
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/@swarm-city/ui-library/-/ui-library-0.3.0.tgz",
@@ -13063,10 +12462,6 @@
 			"version": "2.4.1",
 			"dev": true
 		},
-		"@types/parse-json": {
-			"version": "4.0.0",
-			"dev": true
-		},
 		"@types/pbkdf2": {
 			"version": "3.1.0",
 			"requires": {
@@ -13075,10 +12470,6 @@
 		},
 		"@types/prop-types": {
 			"version": "15.7.5",
-			"dev": true
-		},
-		"@types/q": {
-			"version": "1.5.5",
 			"dev": true
 		},
 		"@types/reach__router": {
@@ -13511,17 +12902,6 @@
 				"es-shim-unscopables": "^1.0.0"
 			}
 		},
-		"array.prototype.reduce": {
-			"version": "1.0.4",
-			"dev": true,
-			"requires": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.19.2",
-				"es-array-method-boxes-properly": "^1.0.0",
-				"is-string": "^1.0.7"
-			}
-		},
 		"arrify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
@@ -13626,10 +13006,6 @@
 		},
 		"bn.js": {
 			"version": "5.2.1"
-		},
-		"boolbase": {
-			"version": "1.0.0",
-			"dev": true
 		},
 		"brace-expansion": {
 			"version": "1.1.11",
@@ -13891,15 +13267,6 @@
 		"clsx": {
 			"version": "1.2.1"
 		},
-		"coa": {
-			"version": "2.0.2",
-			"dev": true,
-			"requires": {
-				"@types/q": "^1.5.1",
-				"chalk": "^2.4.1",
-				"q": "^1.1.2"
-			}
-		},
 		"color-convert": {
 			"version": "1.9.3",
 			"requires": {
@@ -13944,23 +13311,6 @@
 				}
 			}
 		},
-		"cosmiconfig": {
-			"version": "7.0.1",
-			"dev": true,
-			"requires": {
-				"@types/parse-json": "^4.0.0",
-				"import-fresh": "^3.2.1",
-				"parse-json": "^5.0.0",
-				"path-type": "^4.0.0",
-				"yaml": "^1.10.0"
-			},
-			"dependencies": {
-				"yaml": {
-					"version": "1.10.2",
-					"dev": true
-				}
-			}
-		},
 		"create-hash": {
 			"version": "1.2.0",
 			"requires": {
@@ -13994,53 +13344,6 @@
 				"path-key": "^3.1.0",
 				"shebang-command": "^2.0.0",
 				"which": "^2.0.1"
-			}
-		},
-		"css-select": {
-			"version": "2.1.0",
-			"dev": true,
-			"requires": {
-				"boolbase": "^1.0.0",
-				"css-what": "^3.2.1",
-				"domutils": "^1.7.0",
-				"nth-check": "^1.0.2"
-			}
-		},
-		"css-select-base-adapter": {
-			"version": "0.1.1",
-			"dev": true
-		},
-		"css-tree": {
-			"version": "1.0.0-alpha.37",
-			"dev": true,
-			"requires": {
-				"mdn-data": "2.0.4",
-				"source-map": "^0.6.1"
-			}
-		},
-		"css-what": {
-			"version": "3.4.2",
-			"dev": true
-		},
-		"csso": {
-			"version": "4.2.0",
-			"dev": true,
-			"requires": {
-				"css-tree": "^1.1.2"
-			},
-			"dependencies": {
-				"css-tree": {
-					"version": "1.1.3",
-					"dev": true,
-					"requires": {
-						"mdn-data": "2.0.14",
-						"source-map": "^0.6.1"
-					}
-				},
-				"mdn-data": {
-					"version": "2.0.14",
-					"dev": true
-				}
 			}
 		},
 		"csstype": {
@@ -14098,10 +13401,6 @@
 		},
 		"deep-is": {
 			"version": "0.1.4",
-			"dev": true
-		},
-		"deepmerge": {
-			"version": "4.2.2",
 			"dev": true
 		},
 		"default-gateway": {
@@ -14227,32 +13526,6 @@
 				"esutils": "^2.0.2"
 			}
 		},
-		"dom-serializer": {
-			"version": "0.2.2",
-			"dev": true,
-			"requires": {
-				"domelementtype": "^2.0.1",
-				"entities": "^2.0.0"
-			},
-			"dependencies": {
-				"domelementtype": {
-					"version": "2.3.0",
-					"dev": true
-				}
-			}
-		},
-		"domelementtype": {
-			"version": "1.3.1",
-			"dev": true
-		},
-		"domutils": {
-			"version": "1.7.0",
-			"dev": true,
-			"requires": {
-				"dom-serializer": "0",
-				"domelementtype": "1"
-			}
-		},
 		"eastasianwidth": {
 			"version": "0.2.0",
 			"dev": true
@@ -14302,10 +13575,6 @@
 				"once": "^1.4.0"
 			}
 		},
-		"entities": {
-			"version": "2.2.0",
-			"dev": true
-		},
 		"err-code": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/err-code/-/err-code-3.0.1.tgz",
@@ -14345,10 +13614,6 @@
 				"string.prototype.trimstart": "^1.0.5",
 				"unbox-primitive": "^1.0.2"
 			}
-		},
-		"es-array-method-boxes-properly": {
-			"version": "1.0.0",
-			"dev": true
 		},
 		"es-shim-unscopables": {
 			"version": "1.0.0",
@@ -16294,10 +15559,6 @@
 				"safe-buffer": "^5.1.2"
 			}
 		},
-		"mdn-data": {
-			"version": "2.0.4",
-			"dev": true
-		},
 		"mdurl": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -16457,13 +15718,6 @@
 				}
 			}
 		},
-		"mkdirp": {
-			"version": "0.5.6",
-			"dev": true,
-			"requires": {
-				"minimist": "^1.2.6"
-			}
-		},
 		"mkdirp-classic": {
 			"version": "0.5.3",
 			"dev": true
@@ -16590,13 +15844,6 @@
 				}
 			}
 		},
-		"nth-check": {
-			"version": "1.0.2",
-			"dev": true,
-			"requires": {
-				"boolbase": "~1.0.0"
-			}
-		},
 		"object-assign": {
 			"version": "4.1.1",
 			"dev": true
@@ -16632,16 +15879,6 @@
 				"call-bind": "^1.0.2",
 				"define-properties": "^1.1.3",
 				"es-abstract": "^1.19.1"
-			}
-		},
-		"object.getownpropertydescriptors": {
-			"version": "2.1.4",
-			"dev": true,
-			"requires": {
-				"array.prototype.reduce": "^1.0.4",
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
-				"es-abstract": "^1.20.1"
 			}
 		},
 		"object.hasown": {
@@ -17226,10 +16463,6 @@
 				}
 			}
 		},
-		"q": {
-			"version": "1.5.1",
-			"dev": true
-		},
 		"qrcode": {
 			"version": "1.4.4",
 			"requires": {
@@ -17682,7 +16915,8 @@
 		},
 		"source-map": {
 			"version": "0.6.1",
-			"dev": true
+			"dev": true,
+			"optional": true
 		},
 		"source-map-js": {
 			"version": "1.0.2",
@@ -17718,14 +16952,6 @@
 		},
 		"split-on-first": {
 			"version": "1.1.0"
-		},
-		"sprintf-js": {
-			"version": "1.0.3",
-			"dev": true
-		},
-		"stable": {
-			"version": "0.1.8",
-			"dev": true
 		},
 		"stream-browserify": {
 			"version": "3.0.0",
@@ -17840,46 +17066,6 @@
 		},
 		"supports-preserve-symlinks-flag": {
 			"version": "1.0.0"
-		},
-		"svg-parser": {
-			"version": "2.0.4",
-			"dev": true
-		},
-		"svgo": {
-			"version": "1.3.2",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"coa": "^2.0.2",
-				"css-select": "^2.0.0",
-				"css-select-base-adapter": "^0.1.1",
-				"css-tree": "1.0.0-alpha.37",
-				"csso": "^4.0.2",
-				"js-yaml": "^3.13.1",
-				"mkdirp": "~0.5.1",
-				"object.values": "^1.1.0",
-				"sax": "~1.2.4",
-				"stable": "^0.1.8",
-				"unquote": "~1.1.1",
-				"util.promisify": "~1.0.0"
-			},
-			"dependencies": {
-				"argparse": {
-					"version": "1.0.10",
-					"dev": true,
-					"requires": {
-						"sprintf-js": "~1.0.2"
-					}
-				},
-				"js-yaml": {
-					"version": "3.14.1",
-					"dev": true,
-					"requires": {
-						"argparse": "^1.0.7",
-						"esprima": "^4.0.0"
-					}
-				}
-			}
 		},
 		"taffydb": {
 			"version": "2.6.2",
@@ -18077,10 +17263,6 @@
 				"detect-node": "^2.0.4"
 			}
 		},
-		"unquote": {
-			"version": "1.1.1",
-			"dev": true
-		},
 		"update-browserslist-db": {
 			"version": "1.0.5",
 			"requires": {
@@ -18138,16 +17320,6 @@
 		"util-deprecate": {
 			"version": "1.0.2"
 		},
-		"util.promisify": {
-			"version": "1.0.1",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.2",
-				"has-symbols": "^1.0.1",
-				"object.getownpropertydescriptors": "^2.1.0"
-			}
-		},
 		"uuid": {
 			"version": "8.3.2"
 		},
@@ -18188,16 +17360,6 @@
 						"supports-preserve-symlinks-flag": "^1.0.0"
 					}
 				}
-			}
-		},
-		"vite-plugin-react-svg": {
-			"version": "0.2.0",
-			"dev": true,
-			"requires": {
-				"@babel/plugin-transform-react-jsx": "^7.12.12",
-				"@svgr/core": "^5.5.0",
-				"@svgr/plugin-jsx": "^5.5.0",
-				"@svgr/plugin-svgo": "^5.5.0"
 			}
 		},
 		"wagmi": {

--- a/package.json
+++ b/package.json
@@ -53,8 +53,7 @@
 		"protons": "^5.1.0",
 		"puppeteer": "^16.0.0",
 		"typescript": "^4.7.4",
-		"vite": "^3.0.4",
-		"vite-plugin-react-svg": "^0.2.0"
+		"vite": "^3.0.4"
 	},
 	"engines": {
 		"node": ">=16.0.0"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,10 +1,9 @@
 import { defineConfig } from 'vite'
-import svgLoader from 'vite-plugin-react-svg'
 import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
-	plugins: [react(), svgLoader()],
+	plugins: [react()],
 	css: {
 		modules: {
 			localsConvention: 'camelCaseOnly',


### PR DESCRIPTION
As far as I can see, this is not actually needed and is incompatible with the ViteJS version we're using.

Also, it's now actually possible to run `npm ci` without `--force`.