### PR TITLE
perf: cache available Waku protocols

### DIFF
--- a/src/hooks/use-waku.tsx
+++ b/src/hooks/use-waku.tsx
@@ -71,8 +71,6 @@ export const useWaku = (protocols?: Protocols[]) => {
 	const { waku, availableProtocols, addAvailableProtocols } = useWakuContext()
 	const [waiting, setWaiting] = useState(true)
 
-	console.log({ availableProtocols })
-
 	useEffect(() => {
 		if (!waku) {
 			return

--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -399,12 +399,11 @@ export const MarketplaceItem = () => {
 	const itemId = BigInt(itemIdString)
 
 	const { address } = useAccount()
-	const { waku } = useWakuContext()
 	const { decimals } = useMarketplaceTokenDecimals(id)
 	const contract = useMarketplaceContract(id)
 	const { connector } = useAccount()
 	const navigate = useNavigate()
-	const { replies } = useItemReplies(waku, id, itemId)
+	const { replies } = useItemReplies(id, itemId)
 	const selectedProvider = useSelectProvider(id, itemId)
 	const provider = useMemo(() => {
 		const address = selectedProvider.data?.provider
@@ -416,7 +415,7 @@ export const MarketplaceItem = () => {
 	const name = useMarketplaceName(id)
 
 	// TODO: Replace this with a function that only fetches the appropriate item
-	const { loading, waiting, items, lastUpdate } = useMarketplaceItems(waku, id)
+	const { loading, waiting, items, lastUpdate } = useMarketplaceItems(id)
 	const item = useMemo(() => {
 		return items.find(({ id }) => id.eq(itemId))
 	}, [lastUpdate])

--- a/src/pages/marketplaces/marketplace.tsx
+++ b/src/pages/marketplaces/marketplace.tsx
@@ -3,9 +3,6 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useAccount } from 'wagmi'
 import { MarketplaceListingItem, IconButton } from '@swarm-city/ui-library'
 
-// Hooks
-import { useWakuContext } from '../../hooks/use-waku'
-
 // Routes
 import { MARKETPLACE_ADD } from '../../routes'
 
@@ -74,8 +71,7 @@ export const Marketplace = () => {
 	}
 
 	const { address } = useAccount()
-	const { waku } = useWakuContext()
-	const { loading, waiting, items, lastUpdate } = useMarketplaceItems(waku, id)
+	const { loading, waiting, items, lastUpdate } = useMarketplaceItems(id)
 	const { decimals } = useMarketplaceTokenDecimals(id)
 	const navigate = useNavigate()
 	const name = useMarketplaceName(id)

--- a/src/pages/marketplaces/services/marketplace-item.tsx
+++ b/src/pages/marketplaces/services/marketplace-item.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Wallet } from 'ethers'
-import { waitForRemotePeer, WakuMessage, utils } from 'js-waku'
+import { waitForRemotePeer, WakuMessage, utils, Protocols } from 'js-waku'
 import { verifyTypedData } from '@ethersproject/wallet'
 import { getAddress } from '@ethersproject/address'
 
@@ -14,6 +14,9 @@ import type { BigNumber, Signer } from 'ethers'
 
 // Protos
 import { ItemReply } from '../../../protos/ItemReply'
+
+// Hooks
+import { useWaku } from '../../../hooks/use-waku'
 
 export type CreateReply = {
 	text: string
@@ -139,23 +142,11 @@ const decodeWakuReplies = (
 	)
 }
 
-export const useItemReplies = (
-	waku: Waku | undefined,
-	marketplace: string,
-	item: bigint
-) => {
-	const [waiting, setWaiting] = useState(true)
+export const useItemReplies = (marketplace: string, item: bigint) => {
+	const { waku, waiting } = useWaku([Protocols.Store])
 	const [loading, setLoading] = useState(false)
 	const [replies, setReplies] = useState<ItemReplyClean[]>([])
 	const [lastUpdate, setLastUpdate] = useState(Date.now())
-
-	useEffect(() => {
-		if (!waku) {
-			return
-		}
-
-		waitForRemotePeer(waku).then(() => setWaiting(false))
-	}, [waku])
 
 	useEffect(() => {
 		if (!waku || waiting) {

--- a/src/pages/marketplaces/services/marketplace-items.tsx
+++ b/src/pages/marketplaces/services/marketplace-items.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { waitForRemotePeer, Waku, WakuMessage } from 'js-waku'
+import { Protocols, waitForRemotePeer, Waku, WakuMessage } from 'js-waku'
 import { BigNumber, Contract, Event } from 'ethers'
 import { useProvider } from 'wagmi'
 import { Interface } from 'ethers/lib/utils'
@@ -18,6 +18,7 @@ import erc20Abi from '../../../abis/erc20.json'
 // Lib
 import { bufferToHex, numberToBigInt } from '../../../lib/tools'
 import { shouldUpdate } from '../../../lib/blockchain'
+import { useWaku } from '../../../hooks/use-waku'
 
 // Status
 export enum Status {
@@ -130,22 +131,11 @@ const decodeWakuMessages = (messages: WakuMessage[]): Promise<WakuItem>[] => {
 	)
 }
 
-export const useGetWakuItems = (
-	waku: Waku | undefined,
-	marketplace: string
-) => {
-	const [waiting, setWaiting] = useState(true)
+export const useGetWakuItems = (marketplace: string) => {
+	const { waku, waiting } = useWaku([Protocols.Store])
 	const [loading, setLoading] = useState(true)
 	const [items, setItems] = useState<WakuItem[]>([])
 	const [lastUpdate, setLastUpdate] = useState(Date.now())
-
-	useEffect(() => {
-		if (!waku) {
-			return
-		}
-
-		waitForRemotePeer(waku).then(() => setWaiting(false))
-	}, [waku])
 
 	useEffect(() => {
 		if (!waku || waiting) {
@@ -290,11 +280,8 @@ export const useGetMarketplaceItems = (address: string) => {
 	return { loading, items, lastUpdate }
 }
 
-export const useMarketplaceItems = (
-	waku: Waku | undefined,
-	marketplace: string
-) => {
-	const wakuItems = useGetWakuItems(waku, marketplace)
+export const useMarketplaceItems = (marketplace: string) => {
+	const wakuItems = useGetWakuItems(marketplace)
 	const chainItems = useGetMarketplaceItems(marketplace)
 	const [items, setItems] = useState<Item[]>([])
 	const [lastUpdate, setLastUpdate] = useState(Date.now())


### PR DESCRIPTION
As [recommended by Frank](https://discord.com/channels/864066763682218004/865466694554484738/1014358834069909624), we should not be using `waitForRemotePeer` every time we need a protocol. Instead, once it is marked as available, we should just use it.

This might come with issues in case we lose the peer we relied on for said protocol, but in the meantime this at least makes the app somewhat useable without having to hard reload all the time.

-----

We could use an object for `availableProtocols` (i.e. a `Record<Protocols,  boolean>`), but as there's only 4 protocols available, the current implementation should not cause any performance issues.