### PR TITLE
fix: `useWakuStoreQuery` race condition and errors

### DIFF
--- a/src/services/waku.ts
+++ b/src/services/waku.ts
@@ -38,11 +38,7 @@ export const useWakuStoreQuery = (
 
 		// Early abort if the effect was replaced
 		const callback = (messages: WakuMessage[]) => {
-			if (cancelled) {
-				return true
-			}
-
-			return _callback?.(messages)
+			return cancelled ? true : _callback?.(messages)
 		}
 
 		waku.store

--- a/src/services/waku.ts
+++ b/src/services/waku.ts
@@ -19,25 +19,43 @@ import { useWaku } from '../hooks/use-waku'
 export type WakuMessageWithPayload = WakuMessage & { get payload(): Uint8Array }
 
 export const useWakuStoreQuery = (
-	callback: QueryOptions['callback'],
+	_callback: QueryOptions['callback'],
 	getTopic: () => string,
 	dependencies: DependencyList,
 	options: Omit<QueryOptions, 'callback'> = {}
 ) => {
 	const { waku, waiting } = useWaku([Protocols.Store])
 	const [loading, setLoading] = useState(true)
+	const [error, setError] = useState<string>()
 
 	useEffect(() => {
 		if (!waku || waiting) {
 			return
 		}
 
+		let cancelled = false
+		setLoading(true)
+
+		// Early abort if the effect was replaced
+		const callback = (messages: WakuMessage[]) => {
+			if (cancelled) {
+				return true
+			}
+
+			return _callback?.(messages)
+		}
+
 		waku.store
 			.queryHistory([getTopic()], { callback, ...options })
-			.then(() => setLoading(false))
+			.catch((error) => !cancelled && setError(error))
+			.finally(() => !cancelled && setLoading(false))
+
+		return () => {
+			cancelled = true
+		}
 	}, [waiting, ...dependencies])
 
-	return { waiting, loading }
+	return { waiting, loading, error }
 }
 
 export const postWakuMessage = async (


### PR DESCRIPTION
This goes one step towards better error handling and avoids potential race conditions if the dependencies change before `queryHistory` in `useEffect` completes.