### PR TITLE
fix: remove wait for remote peer

### DIFF
--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -6,7 +6,7 @@ import { hexlify, splitSignature } from '@ethersproject/bytes'
 import { getAddress } from '@ethersproject/address'
 
 // Hooks
-import { useWaku, useWakuContext } from '../../hooks/use-waku'
+import { useWaku } from '../../hooks/use-waku'
 
 // Lib
 import { bufferToHex, displayAddress } from '../../lib/tools'
@@ -75,7 +75,7 @@ const ReplyForm = ({
 	const [text, setText] = useState('')
 	const [profile] = useStore.profile()
 
-	const { waku } = useWakuContext()
+	const { waku, waiting } = useWaku()
 	const { connector } = useAccount()
 
 	const postReply = async (event: FormEvent<HTMLElement>) => {
@@ -155,7 +155,11 @@ const ReplyForm = ({
 			</div>
 			<div style={{ marginTop: 26 }}>
 				<IconButton variant="cancel" onClick={onCancel} />
-				<IconButton variant="confirmAction" onClick={postReply} />
+				<IconButton
+					variant="confirmAction"
+					onClick={postReply}
+					disabled={waiting}
+				/>
 			</div>
 		</div>
 	)
@@ -182,7 +186,7 @@ const Reply = ({
 	item: bigint
 	canSelectProvider: boolean
 }) => {
-	const { waku } = useWaku()
+	const { waku, waiting } = useWaku()
 
 	// Wagmi
 	const { connector } = useAccount()
@@ -275,7 +279,7 @@ const Reply = ({
 				detail
 			/>
 			{showSelectBtn && !selected && (
-				<Button size="large" onClick={selectProvider}>
+				<Button size="large" onClick={selectProvider} disabled={waiting}>
 					select {formatFrom(reply.from, profile?.username)}
 				</Button>
 			)}

--- a/src/pages/marketplaces/list-item.tsx
+++ b/src/pages/marketplaces/list-item.tsx
@@ -3,7 +3,7 @@ import { useParams, useNavigate } from 'react-router'
 import { IconButton, Input, ConfirmModal } from '@swarm-city/ui-library'
 
 // Hooks
-import { useWakuContext } from '../../hooks/use-waku'
+import { useWaku } from '../../hooks/use-waku'
 
 // Types
 import type { MouseEvent } from 'react'
@@ -22,7 +22,7 @@ export const MarketplaceListItem = () => {
 	const [description, setDescription] = useState<string>()
 	const [price, setPrice] = useState<number>()
 	const [confirmationReq, setConfirmationReq] = useState<boolean>(false)
-	const { waku } = useWakuContext()
+	const { waku, waiting } = useWaku()
 	const { connector } = useAccount()
 	const navigate = useNavigate()
 	const fee = 0.5 // TODO: this should somehow be estimated, right?
@@ -51,7 +51,7 @@ export const MarketplaceListItem = () => {
 			{confirmationReq && (
 				<ConfirmModal
 					cancel={{ onClick: () => setConfirmationReq(false) }}
-					confirm={{ onClick: submit }}
+					confirm={{ onClick: submit, disabled: waiting }}
 				>
 					<div style={{ padding: 20 }}>
 						<Typography variant="header-35" style={{ marginBottom: 12 }}>

--- a/src/pages/marketplaces/services/marketplace-item.tsx
+++ b/src/pages/marketplaces/services/marketplace-item.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { Wallet } from 'ethers'
-import { waitForRemotePeer, WakuMessage, utils } from 'js-waku'
+import { WakuMessage, utils } from 'js-waku'
 import { verifyTypedData } from '@ethersproject/wallet'
 import { getAddress } from '@ethersproject/address'
 
@@ -60,8 +60,6 @@ export const createReply = async (
 	{ text }: CreateReply,
 	connector: { getSigner: () => Promise<Signer> }
 ) => {
-	const promise = waitForRemotePeer(waku)
-
 	// Get signer
 	const signer = await connector.getSigner()
 	const from = await signer.getAddress()
@@ -83,10 +81,6 @@ export const createReply = async (
 		from: utils.hexToBytes(from.substring(2).toLowerCase()),
 		signature,
 	})
-
-	// Wait for peers
-	// TODO: Should probably be moved somewhere else so the UI can access the state
-	await promise
 
 	// Post the metadata on Waku
 	const message = await WakuMessage.fromBytes(

--- a/src/pages/marketplaces/services/marketplace-items.tsx
+++ b/src/pages/marketplaces/services/marketplace-items.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from 'react'
-import { waitForRemotePeer, Waku, WakuMessage } from 'js-waku'
+import { Waku, WakuMessage } from 'js-waku'
 import { BigNumber, Contract, Event } from 'ethers'
 import { useProvider } from 'wagmi'
 import { Interface } from 'ethers/lib/utils'
@@ -73,8 +73,6 @@ export const createItem = async (
 	{ price, description }: CreateItem,
 	connector: { getSigner: () => Promise<Signer> }
 ) => {
-	const promise = waitForRemotePeer(waku)
-
 	// Get signer
 	const signer = await connector.getSigner()
 
@@ -89,10 +87,6 @@ export const createItem = async (
 	const tokenAddress = await contract.token()
 	const token = new Contract(tokenAddress, erc20Abi, signer)
 	const decimals = await token.decimals()
-
-	// Wait for peers
-	// TODO: Should probably be moved somewhere else so the UI can access the state
-	await promise
 
 	// Post the metadata on Waku
 	const message = await WakuMessage.fromBytes(

--- a/src/services/waku.ts
+++ b/src/services/waku.ts
@@ -1,10 +1,5 @@
 import { useEffect, useState } from 'react'
-import {
-	waitForRemotePeer,
-	WakuMessage,
-	PageDirection,
-	Protocols,
-} from 'js-waku'
+import { WakuMessage, PageDirection, Protocols } from 'js-waku'
 
 // Types
 import type { Waku } from 'js-waku'
@@ -59,12 +54,6 @@ export const postWakuMessage = async (
 	topic: string,
 	payload: Uint8Array
 ) => {
-	const promise = waitForRemotePeer(waku)
-
-	// Wait for peers
-	// TODO: Should probably be moved somewhere else so the UI can access the state
-	await promise
-
 	// Post the metadata on Waku
 	const message = await WakuMessage.fromBytes(payload, topic)
 


### PR DESCRIPTION
This should make the application more reactive for functions that post messages to Waku and previously used `waitForRemotePeer`. I also disabled buttons in case we are still waiting for Waku protocols, which makes it a bit more natural.