### PR TITLE
refactor: abstract services away

### DIFF
--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -13,7 +13,6 @@ import { formatFrom } from '../../lib/tools'
 
 // Services
 import {
-	useMarketplaceContract,
 	useMarketplaceItem,
 	useMarketplaceName,
 	useMarketplaceTokenDecimals,
@@ -26,7 +25,7 @@ import {
 import { Item, Status, useMarketplaceItems } from './services/marketplace-items'
 import { useProfile } from '../../services/profile'
 import { useProfilePictureURL } from '../../services/profile-picture'
-import { fundItem } from '../../services/item'
+import { cancelItem, fundItem } from '../../services/item'
 
 // Assets
 import avatarDefault from '../../assets/imgs/avatar.svg?url'
@@ -364,7 +363,6 @@ export const MarketplaceItem = () => {
 
 	const { address } = useAccount()
 	const { decimals } = useMarketplaceTokenDecimals(id)
-	const contract = useMarketplaceContract(id)
 	const { connector } = useAccount()
 	const navigate = useNavigate()
 	const { replies } = useItemReplies(id, itemId)
@@ -427,14 +425,13 @@ export const MarketplaceItem = () => {
 		)
 	}
 
-	const cancelItem = async () => {
-		if (!connector) {
+	const canCancel = connector
+	const cancel = async () => {
+		if (!canCancel) {
 			throw new Error('no connector')
 		}
 
-		const signer = await connector.getSigner()
-		const tx = await contract.connect(signer).cancelItem(itemId)
-		await tx.wait()
+		await cancelItem(connector, id, itemId)
 		navigate(`/marketplace/${id}`)
 	}
 
@@ -590,11 +587,7 @@ export const MarketplaceItem = () => {
 
 				{status === 1 && item.owner === address && (
 					<div style={{ marginTop: 58 }}>
-						<Button
-							variant="danger"
-							onClick={cancelItem}
-							disabled={!contract || !connector}
-						>
+						<Button variant="danger" onClick={cancel} disabled={!canCancel}>
 							cancel this request
 						</Button>
 					</div>

--- a/src/pages/marketplaces/services/marketplace-items.tsx
+++ b/src/pages/marketplaces/services/marketplace-items.tsx
@@ -101,11 +101,10 @@ export const createItem = async (
 	const amountToApprove = amount + (await contract.fee()).toBigInt() / 2n
 
 	// Approve the tokens to be spent by the marketplace
-	let tx = await token.approve(marketplace, amountToApprove)
-	await tx.wait()
+	await token.approve(marketplace, amountToApprove)
 
 	// Post the item on chain
-	tx = await contract.newItem(amount, new Uint8Array(hash))
+	const tx = await contract.newItem(amount, new Uint8Array(hash))
 	await tx.wait()
 }
 

--- a/src/pages/marketplaces/services/marketplace.ts
+++ b/src/pages/marketplaces/services/marketplace.ts
@@ -1,7 +1,11 @@
-import { BigNumber, BigNumberish, Contract } from 'ethers'
+import { BigNumber, BigNumberish, Contract, Signer } from 'ethers'
 import { useEffect, useMemo, useState } from 'react'
 import { useProvider } from 'wagmi'
-import { JsonRpcBatchProvider, JsonRpcProvider } from '@ethersproject/providers'
+import {
+	JsonRpcBatchProvider,
+	JsonRpcProvider,
+	Provider,
+} from '@ethersproject/providers'
 
 // ABIs
 import marketplaceAbi from '../../../abis/marketplace.json'
@@ -26,10 +30,17 @@ export type MarketplaceItem = {
 	status: Status
 }
 
+export const getMarketplaceContract = (
+	address: string,
+	signerOrProvider?: Signer | Provider
+) => {
+	return new Contract(address, marketplaceAbi, signerOrProvider)
+}
+
 export const useMarketplaceContract = (address: string) => {
 	const provider = useProvider()
 	return useMemo(
-		() => new Contract(address, marketplaceAbi, provider),
+		() => getMarketplaceContract(address, provider),
 		[address, provider]
 	)
 }
@@ -101,20 +112,21 @@ export const useMarketplaceName = (address: string) => {
 	return name
 }
 
-export const useMarketplaceTokenContract = (address: string) => {
-	const [token, setToken] = useState<Contract>()
+export const getMarketplaceTokenContract = async (
+	marketplace: string,
+	signerOrProvider?: Signer | Provider
+) => {
+	const contract = useMarketplaceContract(marketplace)
+	return new Contract(await contract.token(), erc20Abi, signerOrProvider)
+}
 
-	// Get the marketplace contract
+export const useMarketplaceTokenContract = (marketplace: string) => {
+	const [token, setToken] = useState<Contract>()
 	const provider = useProvider()
-	const contract = useMarketplaceContract(address)
 
 	useEffect(() => {
-		// eslint-disable-next-line @typescript-eslint/no-extra-semi
-		;(async () => {
-			const token = new Contract(await contract.token(), erc20Abi, provider)
-			setToken(token)
-		})()
-	}, [contract])
+		getMarketplaceTokenContract(marketplace, provider).then(setToken)
+	}, [marketplace, provider])
 
 	return token
 }

--- a/src/pages/marketplaces/services/marketplace.ts
+++ b/src/pages/marketplaces/services/marketplace.ts
@@ -116,7 +116,7 @@ export const getMarketplaceTokenContract = async (
 	marketplace: string,
 	signerOrProvider?: Signer | Provider
 ) => {
-	const contract = useMarketplaceContract(marketplace)
+	const contract = getMarketplaceContract(marketplace)
 	return new Contract(await contract.token(), erc20Abi, signerOrProvider)
 }
 

--- a/src/services/item.ts
+++ b/src/services/item.ts
@@ -33,3 +33,14 @@ export const fundItem = async (
 	const tx = await contract.fundItem(item, v, r, s)
 	await tx.wait()
 }
+
+export const cancelItem = async (
+	connector: { getSigner: () => Promise<Signer> },
+	marketplace: string,
+	item: bigint
+) => {
+	const signer = await connector.getSigner()
+	const contract = getMarketplaceContract(marketplace, signer)
+	const tx = await contract.connect(signer).cancelItem(item)
+	await tx.wait()
+}

--- a/src/services/item.ts
+++ b/src/services/item.ts
@@ -44,3 +44,14 @@ export const cancelItem = async (
 	const tx = await contract.cancelItem(item)
 	await tx.wait()
 }
+
+export const payoutItem = async (
+	connector: { getSigner: () => Promise<Signer> },
+	marketplace: string,
+	item: bigint
+) => {
+	const signer = await connector.getSigner()
+	const contract = getMarketplaceContract(marketplace, signer)
+	const tx = await contract.payoutItem(item)
+	await tx.wait()
+}

--- a/src/services/item.ts
+++ b/src/services/item.ts
@@ -15,7 +15,7 @@ export const fundItem = async (
 	item: bigint,
 	signature: Uint8Array
 ) => {
-	const signer = await connector?.getSigner()
+	const signer = await connector.getSigner()
 	const contract = getMarketplaceContract(marketplace, signer)
 	const token = await getMarketplaceTokenContract(marketplace, signer)
 

--- a/src/services/item.ts
+++ b/src/services/item.ts
@@ -41,6 +41,6 @@ export const cancelItem = async (
 ) => {
 	const signer = await connector.getSigner()
 	const contract = getMarketplaceContract(marketplace, signer)
-	const tx = await contract.connect(signer).cancelItem(item)
+	const tx = await contract.cancelItem(item)
 	await tx.wait()
 }

--- a/src/services/item.ts
+++ b/src/services/item.ts
@@ -1,0 +1,35 @@
+import { splitSignature } from '@ethersproject/bytes'
+
+// Types
+import type { Signer } from 'ethers'
+
+// Services
+import {
+	getMarketplaceContract,
+	getMarketplaceTokenContract,
+} from '../pages/marketplaces/services/marketplace'
+
+export const fundItem = async (
+	connector: { getSigner: () => Promise<Signer> },
+	marketplace: string,
+	item: bigint,
+	signature: Uint8Array
+) => {
+	const signer = await connector?.getSigner()
+	const contract = getMarketplaceContract(marketplace, signer)
+	const token = await getMarketplaceTokenContract(marketplace, signer)
+
+	// Get the price
+	const { price, fee } = await contract.items(item)
+
+	// Convert the price to bigint
+	const amountToApprove = price.add(fee.div(2))
+
+	// Approve the tokens to be spent by the marketplace
+	await token.approve(marketplace, amountToApprove)
+
+	// Fund the item
+	const { v, r, s } = splitSignature(signature)
+	const tx = await contract.fundItem(item, v, r, s)
+	await tx.wait()
+}


### PR DESCRIPTION
This is basically cleanup so the "backend" stuff doesn't happen directly in the components.

I also added the `payoutItem` function, which should have been in a separate PR, but this makes it a bit easier I guess.

EDIT: Also added some UI for the payout function so it could be tested... 😬 