### PR TITLE
chore: update `js-waku` to `v0.29.0`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"classnames": "^2.3.1",
 				"ethers": "^5.6.9",
 				"eventemitter3": "^4.0.7",
-				"js-waku": "^0.28.0",
+				"js-waku": "^0.29.0",
 				"protons-runtime": "^3.1.0",
 				"qrcode.react": "^3.1.0",
 				"react": "^18.2.0",
@@ -6228,9 +6228,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-waku": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.28.0.tgz",
-			"integrity": "sha512-MEIFugvio2IaQMQT+g+bn24BvlJ5S4PdSKD0AGVZlR7q1BhECwlpRoytyz0A/hC1+EJWhrZB8cpIAmxwtYWTBw==",
+			"version": "0.29.0",
+			"resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.29.0.tgz",
+			"integrity": "sha512-44GOpNbkFt/1/bDZ3tcaeemehaZaxw404QmTvHw7FUwY6dtvGsDEERLEw1TERUljDESFjvEOcJjYnLcNDY1MHg==",
 			"dependencies": {
 				"@chainsafe/libp2p-gossipsub": "^4.1.1",
 				"@chainsafe/libp2p-noise": "^8.0.1",
@@ -14341,9 +14341,9 @@
 			"version": "4.0.0"
 		},
 		"js-waku": {
-			"version": "0.28.0",
-			"resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.28.0.tgz",
-			"integrity": "sha512-MEIFugvio2IaQMQT+g+bn24BvlJ5S4PdSKD0AGVZlR7q1BhECwlpRoytyz0A/hC1+EJWhrZB8cpIAmxwtYWTBw==",
+			"version": "0.29.0",
+			"resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.29.0.tgz",
+			"integrity": "sha512-44GOpNbkFt/1/bDZ3tcaeemehaZaxw404QmTvHw7FUwY6dtvGsDEERLEw1TERUljDESFjvEOcJjYnLcNDY1MHg==",
 			"requires": {
 				"@chainsafe/libp2p-gossipsub": "^4.1.1",
 				"@chainsafe/libp2p-noise": "^8.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
 				"classnames": "^2.3.1",
 				"ethers": "^5.6.9",
 				"eventemitter3": "^4.0.7",
-				"js-waku": "^0.24.0-e3bef47",
+				"js-waku": "^0.28.0",
 				"protons-runtime": "^3.1.0",
 				"qrcode.react": "^3.1.0",
 				"react": "^18.2.0",
@@ -67,11 +67,6 @@
 			"engines": {
 				"node": ">= 12"
 			}
-		},
-		"node_modules/@achingbrain/ip-address/node_modules/sprintf-js": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
 		},
 		"node_modules/@achingbrain/nat-port-mapper": {
 			"version": "1.0.7",
@@ -567,60 +562,48 @@
 			}
 		},
 		"node_modules/@chainsafe/libp2p-gossipsub": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-3.5.0.tgz",
-			"integrity": "sha512-2Lp2dfWpO17dKAzOmnIQqaoPx0MA/dRLPj1q1QSCafW6+obOPGIUJcw1i1+AcBzizDdlZxmmrQx07FlYc0n+Vw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-4.1.1.tgz",
+			"integrity": "sha512-W3z52uTVm48qvwTAcE+tz6ML2CPWA4ErmuL2aCWAW8S7ce6iH8anqo+xI9rcedyIOChWMWLLD4Gtaj4TMrWacw==",
 			"dependencies": {
-				"@libp2p/components": "^2.0.0",
-				"@libp2p/crypto": "^1.0.0",
-				"@libp2p/interface-connection": "^2.0.0",
-				"@libp2p/interface-keys": "^1.0.2",
-				"@libp2p/interface-peer-id": "^1.0.2",
-				"@libp2p/interface-pubsub": "^1.0.1",
-				"@libp2p/interface-registrar": "^2.0.0",
-				"@libp2p/interfaces": "^3.0.2",
+				"@libp2p/components": "^2.0.3",
+				"@libp2p/crypto": "^1.0.3",
+				"@libp2p/interface-connection": "^3.0.1",
+				"@libp2p/interface-keys": "^1.0.3",
+				"@libp2p/interface-peer-id": "^1.0.4",
+				"@libp2p/interface-pubsub": "^2.0.1",
+				"@libp2p/interface-registrar": "^2.0.3",
+				"@libp2p/interfaces": "^3.0.3",
 				"@libp2p/logger": "^2.0.0",
-				"@libp2p/peer-id": "^1.1.13",
-				"@libp2p/peer-record": "^2.0.0",
-				"@libp2p/pubsub": "^3.0.0",
+				"@libp2p/peer-id": "^1.1.15",
+				"@libp2p/peer-record": "^4.0.1",
+				"@libp2p/pubsub": "^3.1.2",
 				"@libp2p/topology": "^3.0.0",
 				"abortable-iterator": "^4.0.2",
 				"denque": "^1.5.0",
 				"err-code": "^3.0.1",
-				"it-length-prefixed": "^7.0.1",
-				"it-pipe": "^2.0.3",
-				"it-pushable": "^3.0.0",
+				"it-length-prefixed": "^8.0.2",
+				"it-pipe": "^2.0.4",
+				"it-pushable": "^3.1.0",
 				"multiformats": "^9.6.4",
 				"protobufjs": "^6.11.2",
+				"uint8arraylist": "^2.3.2",
 				"uint8arrays": "^3.0.0"
-			}
-		},
-		"node_modules/@chainsafe/libp2p-gossipsub/node_modules/@libp2p/interface-connection": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-2.1.1.tgz",
-			"integrity": "sha512-gjugaMsZvfo3r4tCc/yPifVQsfLogmEmJtW+eXMNiNDna3ZfmwWD9Z+KyEwuVsXKs0C4GESXei2y4SJSCEfkbA==",
-			"dependencies": {
-				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0",
-				"@multiformats/multiaddr": "^10.2.0",
-				"it-stream-types": "^1.0.4"
 			},
 			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
+				"npm": ">=8.7.0"
 			}
 		},
 		"node_modules/@chainsafe/libp2p-noise": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-7.0.3.tgz",
-			"integrity": "sha512-kr68a6zEC2y1sp9O1i8MlPu7LgC4U1sLciG/SF9Hvo0kOdDa5a13l3Il9R3rTIqaL9DoVfmQhfpOR/cxY2PWUw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-8.0.1.tgz",
+			"integrity": "sha512-mr1/CMTBIfraqTY4OWBdmJ2v+0+D89vbIp1nJTHz64oDPRgU0Ah8wb7K5hgs0erU8aYMkgMtbhXeouhJK3A7wA==",
 			"dependencies": {
 				"@libp2p/crypto": "^1.0.0",
-				"@libp2p/interface-connection-encrypter": "^1.0.2",
+				"@libp2p/interface-connection-encrypter": "^2.0.1",
 				"@libp2p/interface-keys": "^1.0.2",
 				"@libp2p/interface-peer-id": "^1.0.2",
 				"@libp2p/logger": "^2.0.0",
-				"@libp2p/peer-collections": "^2.0.0",
 				"@libp2p/peer-id": "^1.1.8",
 				"@stablelib/chacha20poly1305": "^1.0.1",
 				"@stablelib/hkdf": "^1.0.1",
@@ -628,44 +611,12 @@
 				"@stablelib/x25519": "^1.0.1",
 				"it-length-prefixed": "^8.0.2",
 				"it-pair": "^2.0.2",
-				"it-pb-stream": "^2.0.1",
+				"it-pb-stream": "^2.0.2",
 				"it-pipe": "^2.0.3",
 				"it-stream-types": "^1.0.4",
-				"protons-runtime": "^2.0.1",
-				"uint8arraylist": "^2.0.0",
-				"uint8arrays": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@chainsafe/libp2p-noise/node_modules/it-length-prefixed": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-			"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-			"dependencies": {
-				"err-code": "^3.0.1",
-				"it-stream-types": "^1.0.4",
-				"uint8-varint": "^1.0.1",
-				"uint8arraylist": "^2.0.0",
-				"uint8arrays": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@chainsafe/libp2p-noise/node_modules/protons-runtime": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-2.0.2.tgz",
-			"integrity": "sha512-6aBGGn4scICr82Emc6+rS1qhxp9I5YUdfaR4lR10BJ6skyQxbh1vEHkrzGqQrawogwbChDrjLG8H6dI+PLh2tg==",
-			"dependencies": {
-				"byte-access": "^1.0.1",
-				"longbits": "^1.1.0",
-				"uint8-varint": "^1.0.2",
-				"uint8arraylist": "^2.0.0",
-				"uint8arrays": "^3.0.0"
+				"protons-runtime": "^3.1.0",
+				"uint8arraylist": "^2.3.2",
+				"uint8arrays": "^3.1.0"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -1544,41 +1495,25 @@
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
 		},
 		"node_modules/@libp2p/components": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@libp2p/components/-/components-2.0.4.tgz",
-			"integrity": "sha512-F04yV6ZrMUEaN8YKxUe2UPsLOnDoME4aMxm+i515aYF0fIZ6qAQfCd0PERvtOnygVnIx+3i3gLsejtL5AVPGUA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@libp2p/components/-/components-2.1.0.tgz",
+			"integrity": "sha512-9xK1pauZiptaR0eJFn1LcOr/hwosU76IjPOqTkRVZVjSStIWmBl+Njrn4qK05Jizopf0cIUnpt/8A6YWjM4D7g==",
 			"dependencies": {
-				"@libp2p/interface-address-manager": "^1.0.1",
+				"@libp2p/interface-address-manager": "^1.0.2",
 				"@libp2p/interface-connection": "^3.0.1",
-				"@libp2p/interface-connection-manager": "^1.0.0",
-				"@libp2p/interface-content-routing": "^1.0.0",
-				"@libp2p/interface-dht": "^1.0.0",
+				"@libp2p/interface-connection-manager": "^1.1.0",
+				"@libp2p/interface-content-routing": "^1.0.2",
+				"@libp2p/interface-dht": "^1.0.1",
 				"@libp2p/interface-metrics": "^3.0.0",
 				"@libp2p/interface-peer-id": "^1.0.2",
-				"@libp2p/interface-peer-routing": "^1.0.0",
-				"@libp2p/interface-peer-store": "^1.0.0",
-				"@libp2p/interface-pubsub": "^2.0.0",
-				"@libp2p/interface-registrar": "^2.0.0",
-				"@libp2p/interface-transport": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.2",
+				"@libp2p/interface-peer-routing": "^1.0.1",
+				"@libp2p/interface-peer-store": "^1.2.1",
+				"@libp2p/interface-pubsub": "^2.1.0",
+				"@libp2p/interface-registrar": "^2.0.3",
+				"@libp2p/interface-transport": "^1.0.3",
+				"@libp2p/interfaces": "^3.0.3",
 				"err-code": "^3.0.1",
 				"interface-datastore": "^7.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/components/node_modules/@libp2p/interface-pubsub": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-2.0.1.tgz",
-			"integrity": "sha512-j6XSYz5Ir5yJH6KCtYMUGYlbBFfDGx/vPfFe1X3UFIC6qZ9N+IMkde6C5DCQ8calhCyM1pB2K5StAlztsZV2BQ==",
-			"dependencies": {
-				"@libp2p/interface-connection": "^3.0.0",
-				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0",
-				"it-pushable": "^3.0.0",
-				"uint8arraylist": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -1603,9 +1538,9 @@
 			}
 		},
 		"node_modules/@libp2p/crypto": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.3.tgz",
-			"integrity": "sha512-YVoSu5eI8gAqfHcT27ovDXtQH6M4rUhV8x2w0FTyPmceU46fVt+lTsMR1woPeN8roByhjCwHjkPzGQ48Do/vwg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.4.tgz",
+			"integrity": "sha512-3hHZvqi+vI8YoTHE+0u8nA5SYGPLZRLMvbgXQoAn0IyPjez66Taaxym/3p3Duf9QkFlvJu95nzpNzv0OdHs9Yw==",
 			"dependencies": {
 				"@libp2p/interface-keys": "^1.0.2",
 				"@noble/ed25519": "^1.6.0",
@@ -1651,12 +1586,13 @@
 			}
 		},
 		"node_modules/@libp2p/interface-connection-encrypter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-1.0.3.tgz",
-			"integrity": "sha512-3HNg52HmanRuV2rbQRMFUVTPceSqoC1+ifK9Jkqw3mbiTXXf1mdsv5uKbqts6QvNY5ABZeQWuqJb2QqibaI0mw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-2.0.1.tgz",
+			"integrity": "sha512-GtqsNJuL1q7LWX3z41t9eFFFrlLSmMH92E0rupoXeFx1dJ8Gs/Zy8b6lZro96Ld6rjU1CeZa87SmYeqQQeHRmw==",
 			"dependencies": {
 				"@libp2p/interface-peer-id": "^1.0.0",
-				"it-stream-types": "^1.0.4"
+				"it-stream-types": "^1.0.4",
+				"uint8arraylist": "^2.1.1"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -1664,13 +1600,14 @@
 			}
 		},
 		"node_modules/@libp2p/interface-connection-manager": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.0.3.tgz",
-			"integrity": "sha512-zDDzAKbtCkqR/3AmZ3DAoK1bt+5vhyUruV8654R9IT5PI7IBBgFnYzvkWHDI/UDvhwT27ubofPagp0m25gQZvg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.1.0.tgz",
+			"integrity": "sha512-mkrkmFAeChwUT4Ay2fRMqGrnkytOYwAOEb4hQHzvX97hP2w4otBzZ9o3FUKtLgGqBd/bVPT/va1XJmXf6E8YTQ==",
 			"dependencies": {
 				"@libp2p/interface-connection": "^3.0.0",
 				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0"
+				"@libp2p/interfaces": "^3.0.0",
+				"@multiformats/multiaddr": "^10.2.0"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -1798,29 +1735,15 @@
 			}
 		},
 		"node_modules/@libp2p/interface-pubsub": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-1.0.4.tgz",
-			"integrity": "sha512-BSkt0h4fbBBHcr3LCF7fTtAoCdQBjKbTGxCa4tIJpI3m5suxC5h6OrLC2rmrexOxR9aZRkr9da4VShRyOfRLag==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-2.1.0.tgz",
+			"integrity": "sha512-X+SIqzfeCO8ZDGrFTzH9EMwMf8ojW5nk20rxv3h1sCXEdfvyJCARZ51r9UlwJcnucnHqvFChfkbubAkrr3R4Cw==",
 			"dependencies": {
-				"@libp2p/interface-connection": "^2.0.0",
+				"@libp2p/interface-connection": "^3.0.0",
 				"@libp2p/interface-peer-id": "^1.0.0",
 				"@libp2p/interfaces": "^3.0.0",
-				"it-pushable": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/interface-pubsub/node_modules/@libp2p/interface-connection": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-2.1.1.tgz",
-			"integrity": "sha512-gjugaMsZvfo3r4tCc/yPifVQsfLogmEmJtW+eXMNiNDna3ZfmwWD9Z+KyEwuVsXKs0C4GESXei2y4SJSCEfkbA==",
-			"dependencies": {
-				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0",
-				"@multiformats/multiaddr": "^10.2.0",
-				"it-stream-types": "^1.0.4"
+				"it-pushable": "^3.0.0",
+				"uint8arraylist": "^2.0.0"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -1907,12 +1830,12 @@
 			}
 		},
 		"node_modules/@libp2p/mplex": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-4.0.3.tgz",
-			"integrity": "sha512-G55n6bC4N7Biy4C6KaAlBfaOAgPFeKEspfQqKVHaUfeE4rmS156hiWCcy1YBZsGHvO7XFCt8IddCkzShStS+6w==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-5.2.2.tgz",
+			"integrity": "sha512-e0EVsOYMiXGiOkLVsGkhg9J/7SWVWMGHhCBvEH4N+s07UEBH/fl+8wgNFyMb8SrdAD2CUP4yaULAMRgUqY4j4Q==",
 			"dependencies": {
 				"@libp2p/components": "^2.0.0",
-				"@libp2p/interface-connection": "^2.0.0",
+				"@libp2p/interface-connection": "^3.0.1",
 				"@libp2p/interface-stream-muxer": "^2.0.0",
 				"@libp2p/logger": "^2.0.0",
 				"@libp2p/tracked-map": "^2.0.0",
@@ -1920,26 +1843,12 @@
 				"any-signal": "^3.0.0",
 				"err-code": "^3.0.1",
 				"it-pipe": "^2.0.3",
-				"it-pushable": "^3.0.0",
+				"it-pushable": "^3.1.0",
 				"it-stream-types": "^1.0.4",
+				"rate-limiter-flexible": "^2.3.9",
 				"uint8arraylist": "^2.1.1",
 				"uint8arrays": "^3.0.0",
 				"varint": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/mplex/node_modules/@libp2p/interface-connection": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-2.1.1.tgz",
-			"integrity": "sha512-gjugaMsZvfo3r4tCc/yPifVQsfLogmEmJtW+eXMNiNDna3ZfmwWD9Z+KyEwuVsXKs0C4GESXei2y4SJSCEfkbA==",
-			"dependencies": {
-				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0",
-				"@multiformats/multiaddr": "^10.2.0",
-				"it-stream-types": "^1.0.4"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -1964,22 +1873,6 @@
 				"it-stream-types": "^1.0.4",
 				"p-defer": "^4.0.0",
 				"uint8arraylist": "^2.3.1",
-				"uint8arrays": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/multistream-select/node_modules/it-length-prefixed": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-			"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-			"dependencies": {
-				"err-code": "^3.0.1",
-				"it-stream-types": "^1.0.4",
-				"uint8-varint": "^1.0.1",
-				"uint8arraylist": "^2.0.0",
 				"uint8arrays": "^3.0.0"
 			},
 			"engines": {
@@ -2035,80 +1928,30 @@
 			}
 		},
 		"node_modules/@libp2p/peer-record": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-2.0.2.tgz",
-			"integrity": "sha512-JkH9fBpBpGQYqDMJP3+LNtXLyjNCf0fVcBkdjyfPTSwUXTPJ5NxsluJAH+MZkkrJG9YJG22NgrZO5784GSLAaA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-4.0.2.tgz",
+			"integrity": "sha512-r1arc73ADcLd9sESNy7bDHPAsv3JYvIV7kXjB13wQJAQ1oeu9e0I6f1MAIWt4ZukNAiRD8gdlrRvNG63AAZfOg==",
 			"dependencies": {
 				"@libp2p/crypto": "^1.0.0",
 				"@libp2p/interface-peer-id": "^1.0.2",
-				"@libp2p/interface-record": "^1.0.1",
+				"@libp2p/interface-record": "^2.0.1",
 				"@libp2p/logger": "^2.0.0",
 				"@libp2p/peer-id": "^1.1.13",
-				"@libp2p/utils": "^2.0.0",
+				"@libp2p/utils": "^3.0.0",
 				"@multiformats/multiaddr": "^10.1.5",
 				"err-code": "^3.0.1",
-				"interface-datastore": "^6.1.0",
+				"interface-datastore": "^7.0.0",
 				"it-all": "^1.0.6",
 				"it-filter": "^1.0.3",
 				"it-foreach": "^0.1.1",
 				"it-map": "^1.0.6",
 				"it-pipe": "^2.0.3",
 				"multiformats": "^9.6.3",
-				"protons-runtime": "^1.0.4",
+				"protons-runtime": "^3.1.0",
+				"uint8-varint": "^1.0.2",
+				"uint8arraylist": "^2.1.0",
 				"uint8arrays": "^3.0.0",
 				"varint": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/peer-record/node_modules/@libp2p/interface-record": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-1.0.2.tgz",
-			"integrity": "sha512-bYNxKtsUOsNucHeAXCZbAQxFXwR7JvoOmodwEByriMvTWYRbd6d8rm8VHZ/17QgdRFlIwNnpIPuoyyLQ8Wn1rQ==",
-			"dependencies": {
-				"@libp2p/interface-peer-id": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/peer-record/node_modules/interface-datastore": {
-			"version": "6.1.1",
-			"resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
-			"integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
-			"dependencies": {
-				"interface-store": "^2.0.2",
-				"nanoid": "^3.0.2",
-				"uint8arrays": "^3.0.0"
-			}
-		},
-		"node_modules/@libp2p/peer-record/node_modules/interface-store": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
-			"integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
-		},
-		"node_modules/@libp2p/peer-record/node_modules/protons-runtime": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-			"integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-			"dependencies": {
-				"uint8arraylist": "^1.4.0",
-				"uint8arrays": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/peer-record/node_modules/uint8arraylist": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-			"integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-			"dependencies": {
-				"uint8arrays": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -2148,59 +1991,6 @@
 				"npm": ">=7.0.0"
 			}
 		},
-		"node_modules/@libp2p/peer-store/node_modules/@libp2p/peer-record": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-4.0.2.tgz",
-			"integrity": "sha512-r1arc73ADcLd9sESNy7bDHPAsv3JYvIV7kXjB13wQJAQ1oeu9e0I6f1MAIWt4ZukNAiRD8gdlrRvNG63AAZfOg==",
-			"dependencies": {
-				"@libp2p/crypto": "^1.0.0",
-				"@libp2p/interface-peer-id": "^1.0.2",
-				"@libp2p/interface-record": "^2.0.1",
-				"@libp2p/logger": "^2.0.0",
-				"@libp2p/peer-id": "^1.1.13",
-				"@libp2p/utils": "^3.0.0",
-				"@multiformats/multiaddr": "^10.1.5",
-				"err-code": "^3.0.1",
-				"interface-datastore": "^7.0.0",
-				"it-all": "^1.0.6",
-				"it-filter": "^1.0.3",
-				"it-foreach": "^0.1.1",
-				"it-map": "^1.0.6",
-				"it-pipe": "^2.0.3",
-				"multiformats": "^9.6.3",
-				"protons-runtime": "^3.1.0",
-				"uint8-varint": "^1.0.2",
-				"uint8arraylist": "^2.1.0",
-				"uint8arrays": "^3.0.0",
-				"varint": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/peer-store/node_modules/@libp2p/utils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.1.tgz",
-			"integrity": "sha512-qc1zGBb6Yrl/ihux8qmy+T3H9BymVGiZeam8b/Dr4jpHxV4mfYwySYXUxa6LZqhDp0WS2Es9B1v1UtsNRY5YxA==",
-			"dependencies": {
-				"@achingbrain/ip-address": "^8.1.0",
-				"@libp2p/interface-connection": "^3.0.1",
-				"@libp2p/interface-peer-store": "^1.0.0",
-				"@libp2p/logger": "^2.0.0",
-				"@multiformats/multiaddr": "^10.1.1",
-				"abortable-iterator": "^4.0.2",
-				"err-code": "^3.0.1",
-				"is-loopback-addr": "^2.0.1",
-				"it-stream-types": "^1.0.4",
-				"private-ip": "^2.1.1",
-				"uint8arraylist": "^2.3.2"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
 		"node_modules/@libp2p/pubsub": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@libp2p/pubsub/-/pubsub-3.1.2.tgz",
@@ -2225,38 +2015,6 @@
 				"it-pushable": "^3.0.0",
 				"multiformats": "^9.6.3",
 				"p-queue": "^7.2.0",
-				"uint8arraylist": "^2.0.0",
-				"uint8arrays": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/pubsub/node_modules/@libp2p/interface-pubsub": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-2.0.1.tgz",
-			"integrity": "sha512-j6XSYz5Ir5yJH6KCtYMUGYlbBFfDGx/vPfFe1X3UFIC6qZ9N+IMkde6C5DCQ8calhCyM1pB2K5StAlztsZV2BQ==",
-			"dependencies": {
-				"@libp2p/interface-connection": "^3.0.0",
-				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0",
-				"it-pushable": "^3.0.0",
-				"uint8arraylist": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/pubsub/node_modules/it-length-prefixed": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-			"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-			"dependencies": {
-				"err-code": "^3.0.1",
-				"it-stream-types": "^1.0.4",
-				"uint8-varint": "^1.0.1",
 				"uint8arraylist": "^2.0.0",
 				"uint8arrays": "^3.0.0"
 			},
@@ -2295,67 +2053,6 @@
 			}
 		},
 		"node_modules/@libp2p/utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-2.0.1.tgz",
-			"integrity": "sha512-R0r9fkskuTmm5jMrlRXWpTdYJeDYcNQ1KdfSEmoVlCs5AlTeWn31+cdaHQihSEbkpEKtVCExfsZkwa3f7C1l8A==",
-			"dependencies": {
-				"@achingbrain/ip-address": "^8.1.0",
-				"@libp2p/interface-connection": "^1.0.1",
-				"@libp2p/interface-peer-store": "^1.0.0",
-				"@libp2p/logger": "^2.0.0",
-				"@multiformats/multiaddr": "^10.1.1",
-				"abortable-iterator": "^4.0.2",
-				"err-code": "^3.0.1",
-				"is-loopback-addr": "^2.0.1",
-				"it-stream-types": "^1.0.4",
-				"private-ip": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/utils/node_modules/@libp2p/interface-connection": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-1.0.1.tgz",
-			"integrity": "sha512-4MP+RvqR5xu6EWgrebLo34HWm/X+hGXtzsCKmNfmLN9bpaYhEobzL4Rm3RYi/0ICrgAZmoU8n+x8widiuwERew==",
-			"dependencies": {
-				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0",
-				"@multiformats/multiaddr": "^10.2.0",
-				"it-stream-types": "^1.0.4"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/websockets": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-3.0.2.tgz",
-			"integrity": "sha512-hC8sNK7A8EkCkUaDMf56idAadoN1lteFpSsZo4GUKeYmClBpPf116tntIR4HN8SgnQ4ssPG6y9zkqGFcOtviCg==",
-			"dependencies": {
-				"@libp2p/interface-connection": "^3.0.1",
-				"@libp2p/interface-transport": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.1",
-				"@libp2p/logger": "^2.0.0",
-				"@libp2p/utils": "^3.0.0",
-				"@multiformats/mafmt": "^11.0.2",
-				"@multiformats/multiaddr": "^10.1.5",
-				"@multiformats/multiaddr-to-uri": "^9.0.0",
-				"abortable-iterator": "^4.0.2",
-				"err-code": "^3.0.1",
-				"it-ws": "^5.0.0",
-				"p-defer": "^4.0.0",
-				"p-timeout": "^6.0.0",
-				"wherearewe": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/@libp2p/websockets/node_modules/@libp2p/utils": {
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.1.tgz",
 			"integrity": "sha512-qc1zGBb6Yrl/ihux8qmy+T3H9BymVGiZeam8b/Dr4jpHxV4mfYwySYXUxa6LZqhDp0WS2Es9B1v1UtsNRY5YxA==",
@@ -2377,6 +2074,31 @@
 				"npm": ">=7.0.0"
 			}
 		},
+		"node_modules/@libp2p/websockets": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-3.0.3.tgz",
+			"integrity": "sha512-fGbXpbyJaToA3Opc/lyw3C2xGlhDiabwQeQE6bTNTCpCFsBwOq8DwE4J++lkxnvJzKu0D4oC1c7oQrQ+4oq1Fw==",
+			"dependencies": {
+				"@libp2p/interface-connection": "^3.0.1",
+				"@libp2p/interface-transport": "^1.0.0",
+				"@libp2p/interfaces": "^3.0.1",
+				"@libp2p/logger": "^2.0.0",
+				"@libp2p/utils": "^3.0.0",
+				"@multiformats/mafmt": "^11.0.2",
+				"@multiformats/multiaddr": "^10.1.5",
+				"@multiformats/multiaddr-to-uri": "^9.0.0",
+				"abortable-iterator": "^4.0.2",
+				"err-code": "^3.0.1",
+				"it-ws": "^5.0.0",
+				"p-defer": "^4.0.0",
+				"p-timeout": "^6.0.0",
+				"wherearewe": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16.0.0",
+				"npm": ">=7.0.0"
+			}
+		},
 		"node_modules/@metamask/safe-event-emitter": {
 			"version": "2.0.0",
 			"license": "ISC"
@@ -2390,13 +2112,13 @@
 			}
 		},
 		"node_modules/@multiformats/multiaddr": {
-			"version": "10.3.3",
-			"resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.3.3.tgz",
-			"integrity": "sha512-+LX9RovG7DJsANb+U6VchV/tApcdJzeafbi5+MPUam90oL91BbEh6ozNZOz4Qf5ZEeilexc12oomatmODJh1/w==",
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.4.3.tgz",
+			"integrity": "sha512-yHhYKOnzvjxyF5xMwbHFI9hBi0xQIa6y0dnTlOUs+CKsJCn8NfwznCjXmW7HH0IIiFobJGgs3UNY0bWLWIrqWw==",
 			"dependencies": {
 				"dns-over-http-resolver": "^2.1.0",
 				"err-code": "^3.0.1",
-				"is-ip": "^4.0.0",
+				"is-ip": "^5.0.0",
 				"multiformats": "^9.4.5",
 				"uint8arrays": "^3.0.0",
 				"varint": "^6.0.0"
@@ -2415,9 +2137,9 @@
 			}
 		},
 		"node_modules/@noble/ed25519": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.6.1.tgz",
-			"integrity": "sha512-Gptpue6qPmg7p1E5LBO5GDtXw5WMc2DVtUmu4EQequOcoCvum1dT9sY6s9M8aSJWq9YopCN4jmTOAvqMdw3q7w==",
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
+			"integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2426,9 +2148,9 @@
 			]
 		},
 		"node_modules/@noble/secp256k1": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
-			"integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
+			"integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw==",
 			"funding": [
 				{
 					"type": "individual",
@@ -2609,9 +2331,9 @@
 			}
 		},
 		"node_modules/@stablelib/random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.1.tgz",
-			"integrity": "sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+			"integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
 			"dependencies": {
 				"@stablelib/binary": "^1.0.1",
 				"@stablelib/wipe": "^1.0.1"
@@ -2633,12 +2355,12 @@
 			"integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
 		},
 		"node_modules/@stablelib/x25519": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.2.tgz",
-			"integrity": "sha512-wTR0t0Bp1HABLFRbYaE3vFLuco2QbAg6QvxBnzi5j9qjhYezWHW7OiCZyaWbt25UkSaoolUUT4Il0nS/2vcbSw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
+			"integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
 			"dependencies": {
 				"@stablelib/keyagreement": "^1.0.1",
-				"@stablelib/random": "^1.0.1",
+				"@stablelib/random": "^1.0.2",
 				"@stablelib/wipe": "^1.0.1"
 			}
 		},
@@ -3972,6 +3694,20 @@
 				"node": ">=0.8"
 			}
 		},
+		"node_modules/clone-regexp": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
+			"integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
+			"dependencies": {
+				"is-regexp": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/clsx": {
 			"version": "1.2.1",
 			"license": "MIT",
@@ -4006,6 +3742,17 @@
 		"node_modules/concat-map": {
 			"version": "0.0.1",
 			"license": "MIT"
+		},
+		"node_modules/convert-hrtime": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+			"integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/convert-source-map": {
 			"version": "1.8.0",
@@ -5493,6 +5240,17 @@
 			"version": "1.1.1",
 			"license": "MIT"
 		},
+		"node_modules/function-timeout": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
+			"integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg==",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/function.prototype.name": {
 			"version": "1.1.5",
 			"license": "MIT",
@@ -6092,14 +5850,15 @@
 			}
 		},
 		"node_modules/is-ip": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-4.0.0.tgz",
-			"integrity": "sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
+			"integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
 			"dependencies": {
-				"ip-regex": "^5.0.0"
+				"ip-regex": "^5.0.0",
+				"super-regex": "^0.2.0"
 			},
 			"engines": {
-				"node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+				"node": ">=14.16"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -6161,6 +5920,17 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"node_modules/is-regexp": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+			"integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/is-shared-array-buffer": {
@@ -6299,25 +6069,14 @@
 			}
 		},
 		"node_modules/it-length-prefixed": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-7.0.1.tgz",
-			"integrity": "sha512-UozKoT0zZPUa0LO9OSq5KaLKPn83U7Vsy/BNAN0TUXfTI/pKrOz6RuyTSOok6NDad12FZsShBGnl9DKlfDT95g==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
+			"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
 			"dependencies": {
 				"err-code": "^3.0.1",
 				"it-stream-types": "^1.0.4",
-				"uint8arraylist": "^1.2.0",
-				"varint": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/it-length-prefixed/node_modules/uint8arraylist": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-			"integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-			"dependencies": {
+				"uint8-varint": "^1.0.1",
+				"uint8arraylist": "^2.0.0",
 				"uint8arrays": "^3.0.0"
 			},
 			"engines": {
@@ -6368,22 +6127,6 @@
 				"it-length-prefixed": "^8.0.2",
 				"it-stream-types": "^1.0.4",
 				"uint8arraylist": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/it-pb-stream/node_modules/it-length-prefixed": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-			"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-			"dependencies": {
-				"err-code": "^3.0.1",
-				"it-stream-types": "^1.0.4",
-				"uint8-varint": "^1.0.1",
-				"uint8arraylist": "^2.0.0",
-				"uint8arrays": "^3.0.0"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -6485,65 +6228,42 @@
 			"license": "MIT"
 		},
 		"node_modules/js-waku": {
-			"version": "0.24.0-e3bef47",
-			"resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.24.0-e3bef47.tgz",
-			"integrity": "sha512-TWZvQJuVBVDlBJfbyXBQGj5TyIXgPN3liM3PD8xDmMy9p8Fdn7KFpdjGdUho3ANLXRiOEpwCSGjO7OvFPH/87A==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.28.0.tgz",
+			"integrity": "sha512-MEIFugvio2IaQMQT+g+bn24BvlJ5S4PdSKD0AGVZlR7q1BhECwlpRoytyz0A/hC1+EJWhrZB8cpIAmxwtYWTBw==",
 			"dependencies": {
-				"@chainsafe/libp2p-gossipsub": "^3.4.0",
-				"@chainsafe/libp2p-noise": "^7.0.1",
+				"@chainsafe/libp2p-gossipsub": "^4.1.1",
+				"@chainsafe/libp2p-noise": "^8.0.1",
 				"@ethersproject/rlp": "^5.5.0",
-				"@libp2p/crypto": "^1.0.0",
+				"@libp2p/crypto": "^1.0.4",
 				"@libp2p/interface-connection": "3.0.1",
 				"@libp2p/interface-peer-discovery": "^1.0.0",
 				"@libp2p/interface-peer-id": "^1.0.2",
 				"@libp2p/interface-peer-info": "^1.0.1",
 				"@libp2p/interface-peer-store": "^1.0.0",
+				"@libp2p/interface-pubsub": "^2.0.1",
 				"@libp2p/interfaces": "^3.0.2",
-				"@libp2p/mplex": "^4.0.1",
+				"@libp2p/mplex": "^5.1.1",
 				"@libp2p/peer-id": "^1.1.10",
-				"@libp2p/websockets": "^3.0.0",
-				"@multiformats/multiaddr": "^10.2.0",
+				"@libp2p/websockets": "^3.0.3",
+				"@multiformats/multiaddr": "^10.4.0",
 				"@noble/secp256k1": "^1.3.4",
 				"debug": "^4.3.4",
 				"dns-query": "^0.11.2",
 				"hi-base32": "^0.5.1",
 				"it-all": "^1.0.6",
-				"it-length-prefixed": "^7.0.1",
+				"it-length-prefixed": "^8.0.2",
 				"it-pipe": "^2.0.4",
 				"js-sha3": "^0.8.0",
-				"libp2p": "next",
+				"libp2p": "0.38.0",
 				"p-event": "^5.0.1",
-				"protons-runtime": "^1.0.4",
+				"protons-runtime": "^3.1.0",
+				"uint8arraylist": "^2.3.2",
 				"uint8arrays": "^3.0.0",
 				"uuid": "^8.3.2"
 			},
 			"engines": {
 				"node": ">=16"
-			}
-		},
-		"node_modules/js-waku/node_modules/protons-runtime": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-			"integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-			"dependencies": {
-				"uint8arraylist": "^1.4.0",
-				"uint8arrays": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/js-waku/node_modules/uint8arraylist": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-			"integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-			"dependencies": {
-				"uint8arrays": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
 			}
 		},
 		"node_modules/js-yaml": {
@@ -6742,9 +6462,9 @@
 			}
 		},
 		"node_modules/libp2p": {
-			"version": "0.37.3-509e56a",
-			"resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.37.3-509e56a.tgz",
-			"integrity": "sha512-iJktQPrRhrtCXMdkIUklUzX36IjR/53cHJ7BtItg2+FgXO0ZMSHvIp96JBDMDGm+GvWpbLb7AMKh0HBnLKGJ4Q==",
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.38.0.tgz",
+			"integrity": "sha512-Wi/ptR69M5LuOrH8hwno98Dg/YeaDXmsyN2cd3vx/yuaEdcgz1RPdGtxxpyVP6J63eZbH07MYTvQcQHH5VhTkA==",
 			"dependencies": {
 				"@achingbrain/nat-port-mapper": "^1.0.3",
 				"@libp2p/components": "^2.0.3",
@@ -6800,7 +6520,7 @@
 				"merge-options": "^3.0.4",
 				"multiformats": "^9.6.3",
 				"mutable-proxy": "^1.0.0",
-				"node-forge": "^1.2.1",
+				"node-forge": "^1.3.1",
 				"p-fifo": "^1.0.0",
 				"p-retry": "^5.0.0",
 				"p-settle": "^5.0.0",
@@ -6814,117 +6534,6 @@
 				"uint8arrays": "^3.0.0",
 				"wherearewe": "^2.0.0",
 				"xsalsa20": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/libp2p/node_modules/@libp2p/interface-connection-encrypter": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-2.0.1.tgz",
-			"integrity": "sha512-GtqsNJuL1q7LWX3z41t9eFFFrlLSmMH92E0rupoXeFx1dJ8Gs/Zy8b6lZro96Ld6rjU1CeZa87SmYeqQQeHRmw==",
-			"dependencies": {
-				"@libp2p/interface-peer-id": "^1.0.0",
-				"it-stream-types": "^1.0.4",
-				"uint8arraylist": "^2.1.1"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/libp2p/node_modules/@libp2p/interface-pubsub": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-2.0.1.tgz",
-			"integrity": "sha512-j6XSYz5Ir5yJH6KCtYMUGYlbBFfDGx/vPfFe1X3UFIC6qZ9N+IMkde6C5DCQ8calhCyM1pB2K5StAlztsZV2BQ==",
-			"dependencies": {
-				"@libp2p/interface-connection": "^3.0.0",
-				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0",
-				"it-pushable": "^3.0.0",
-				"uint8arraylist": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/libp2p/node_modules/@libp2p/peer-record": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-4.0.2.tgz",
-			"integrity": "sha512-r1arc73ADcLd9sESNy7bDHPAsv3JYvIV7kXjB13wQJAQ1oeu9e0I6f1MAIWt4ZukNAiRD8gdlrRvNG63AAZfOg==",
-			"dependencies": {
-				"@libp2p/crypto": "^1.0.0",
-				"@libp2p/interface-peer-id": "^1.0.2",
-				"@libp2p/interface-record": "^2.0.1",
-				"@libp2p/logger": "^2.0.0",
-				"@libp2p/peer-id": "^1.1.13",
-				"@libp2p/utils": "^3.0.0",
-				"@multiformats/multiaddr": "^10.1.5",
-				"err-code": "^3.0.1",
-				"interface-datastore": "^7.0.0",
-				"it-all": "^1.0.6",
-				"it-filter": "^1.0.3",
-				"it-foreach": "^0.1.1",
-				"it-map": "^1.0.6",
-				"it-pipe": "^2.0.3",
-				"multiformats": "^9.6.3",
-				"protons-runtime": "^3.1.0",
-				"uint8-varint": "^1.0.2",
-				"uint8arraylist": "^2.1.0",
-				"uint8arrays": "^3.0.0",
-				"varint": "^6.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/libp2p/node_modules/@libp2p/utils": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.1.tgz",
-			"integrity": "sha512-qc1zGBb6Yrl/ihux8qmy+T3H9BymVGiZeam8b/Dr4jpHxV4mfYwySYXUxa6LZqhDp0WS2Es9B1v1UtsNRY5YxA==",
-			"dependencies": {
-				"@achingbrain/ip-address": "^8.1.0",
-				"@libp2p/interface-connection": "^3.0.1",
-				"@libp2p/interface-peer-store": "^1.0.0",
-				"@libp2p/logger": "^2.0.0",
-				"@multiformats/multiaddr": "^10.1.1",
-				"abortable-iterator": "^4.0.2",
-				"err-code": "^3.0.1",
-				"is-loopback-addr": "^2.0.1",
-				"it-stream-types": "^1.0.4",
-				"private-ip": "^2.1.1",
-				"uint8arraylist": "^2.3.2"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/libp2p/node_modules/it-length-prefixed": {
-			"version": "8.0.2",
-			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-			"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-			"dependencies": {
-				"err-code": "^3.0.1",
-				"it-stream-types": "^1.0.4",
-				"uint8-varint": "^1.0.1",
-				"uint8arraylist": "^2.0.0",
-				"uint8arrays": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=16.0.0",
-				"npm": ">=7.0.0"
-			}
-		},
-		"node_modules/libp2p/node_modules/wherearewe": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
-			"integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
-			"dependencies": {
-				"is-electron": "^2.2.0"
 			},
 			"engines": {
 				"node": ">=16.0.0",
@@ -7585,29 +7194,29 @@
 			"license": "MIT"
 		},
 		"node_modules/mortice": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.0.tgz",
-			"integrity": "sha512-g4rgq//2PWn4m52G6TpCSGmtWabJM8LKCZTQY4W7z0foiaQkqw+FG9a6pwIqUcTkCgBQoet8G/24V6adVMpnHw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
+			"integrity": "sha512-eyDUsl1nCR9+JtNksKnaESLP9MgAXCA4w1LTtsmOSQNsThnv++f36rrBu5fC/fdGIwTJZmbiaR/QewptH93pYA==",
 			"dependencies": {
-				"nanoid": "^3.1.20",
+				"nanoid": "^4.0.0",
 				"observable-webworkers": "^2.0.1",
 				"p-queue": "^7.2.0",
-				"p-timeout": "^5.0.2"
+				"p-timeout": "^6.0.0"
 			},
 			"engines": {
 				"node": ">=16.0.0",
 				"npm": ">=7.0.0"
 			}
 		},
-		"node_modules/mortice/node_modules/p-timeout": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-			"integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
-			"engines": {
-				"node": ">=12"
+		"node_modules/mortice/node_modules/nanoid": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+			"integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg==",
+			"bin": {
+				"nanoid": "bin/nanoid.js"
 			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+			"engines": {
+				"node": "^14 || ^16 || >=18"
 			}
 		},
 		"node_modules/ms": {
@@ -8858,6 +8467,11 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
+		"node_modules/rate-limiter-flexible": {
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.3.10.tgz",
+			"integrity": "sha512-bXqRBBb85WmnJemw9+xLdA7ezLXwZ+hXcOD8ZzfGMhbus4jHRrjTMXZ1kJqpKnpGu34scZc6f0qYNSxBwO7yrg=="
+		},
 		"node_modules/react": {
 			"version": "18.2.0",
 			"license": "MIT",
@@ -9375,7 +8989,8 @@
 		},
 		"node_modules/sax": {
 			"version": "1.2.4",
-			"license": "ISC"
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"node_modules/scheduler": {
 			"version": "0.23.0",
@@ -9563,6 +9178,11 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/sprintf-js": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+		},
 		"node_modules/stream-browserify": {
 			"version": "3.0.0",
 			"license": "MIT",
@@ -9749,6 +9369,22 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/super-regex": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
+			"integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
+			"dependencies": {
+				"clone-regexp": "^3.0.0",
+				"function-timeout": "^0.1.0",
+				"time-span": "^5.1.0"
+			},
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/supports-color": {
 			"version": "5.5.0",
 			"license": "MIT",
@@ -9823,6 +9459,20 @@
 			"version": "2.3.8",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/time-span": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+			"integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+			"dependencies": {
+				"convert-hrtime": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/timeout-abort-controller": {
 			"version": "3.0.0",
@@ -10133,7 +9783,8 @@
 		},
 		"node_modules/uuid": {
 			"version": "8.3.2",
-			"license": "MIT",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
@@ -10251,9 +9902,9 @@
 			}
 		},
 		"node_modules/wherearewe": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
-			"integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+			"integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
 			"dependencies": {
 				"is-electron": "^2.2.0"
 			},
@@ -10642,13 +10293,6 @@
 			"requires": {
 				"jsbn": "1.1.0",
 				"sprintf-js": "1.1.2"
-			},
-			"dependencies": {
-				"sprintf-js": {
-					"version": "1.1.2",
-					"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
-					"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
-				}
 			}
 		},
 		"@achingbrain/nat-port-mapper": {
@@ -10960,58 +10604,45 @@
 			}
 		},
 		"@chainsafe/libp2p-gossipsub": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-3.5.0.tgz",
-			"integrity": "sha512-2Lp2dfWpO17dKAzOmnIQqaoPx0MA/dRLPj1q1QSCafW6+obOPGIUJcw1i1+AcBzizDdlZxmmrQx07FlYc0n+Vw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@chainsafe/libp2p-gossipsub/-/libp2p-gossipsub-4.1.1.tgz",
+			"integrity": "sha512-W3z52uTVm48qvwTAcE+tz6ML2CPWA4ErmuL2aCWAW8S7ce6iH8anqo+xI9rcedyIOChWMWLLD4Gtaj4TMrWacw==",
 			"requires": {
-				"@libp2p/components": "^2.0.0",
-				"@libp2p/crypto": "^1.0.0",
-				"@libp2p/interface-connection": "^2.0.0",
-				"@libp2p/interface-keys": "^1.0.2",
-				"@libp2p/interface-peer-id": "^1.0.2",
-				"@libp2p/interface-pubsub": "^1.0.1",
-				"@libp2p/interface-registrar": "^2.0.0",
-				"@libp2p/interfaces": "^3.0.2",
+				"@libp2p/components": "^2.0.3",
+				"@libp2p/crypto": "^1.0.3",
+				"@libp2p/interface-connection": "^3.0.1",
+				"@libp2p/interface-keys": "^1.0.3",
+				"@libp2p/interface-peer-id": "^1.0.4",
+				"@libp2p/interface-pubsub": "^2.0.1",
+				"@libp2p/interface-registrar": "^2.0.3",
+				"@libp2p/interfaces": "^3.0.3",
 				"@libp2p/logger": "^2.0.0",
-				"@libp2p/peer-id": "^1.1.13",
-				"@libp2p/peer-record": "^2.0.0",
-				"@libp2p/pubsub": "^3.0.0",
+				"@libp2p/peer-id": "^1.1.15",
+				"@libp2p/peer-record": "^4.0.1",
+				"@libp2p/pubsub": "^3.1.2",
 				"@libp2p/topology": "^3.0.0",
 				"abortable-iterator": "^4.0.2",
 				"denque": "^1.5.0",
 				"err-code": "^3.0.1",
-				"it-length-prefixed": "^7.0.1",
-				"it-pipe": "^2.0.3",
-				"it-pushable": "^3.0.0",
+				"it-length-prefixed": "^8.0.2",
+				"it-pipe": "^2.0.4",
+				"it-pushable": "^3.1.0",
 				"multiformats": "^9.6.4",
 				"protobufjs": "^6.11.2",
+				"uint8arraylist": "^2.3.2",
 				"uint8arrays": "^3.0.0"
-			},
-			"dependencies": {
-				"@libp2p/interface-connection": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-2.1.1.tgz",
-					"integrity": "sha512-gjugaMsZvfo3r4tCc/yPifVQsfLogmEmJtW+eXMNiNDna3ZfmwWD9Z+KyEwuVsXKs0C4GESXei2y4SJSCEfkbA==",
-					"requires": {
-						"@libp2p/interface-peer-id": "^1.0.0",
-						"@libp2p/interfaces": "^3.0.0",
-						"@multiformats/multiaddr": "^10.2.0",
-						"it-stream-types": "^1.0.4"
-					}
-				}
 			}
 		},
 		"@chainsafe/libp2p-noise": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-7.0.3.tgz",
-			"integrity": "sha512-kr68a6zEC2y1sp9O1i8MlPu7LgC4U1sLciG/SF9Hvo0kOdDa5a13l3Il9R3rTIqaL9DoVfmQhfpOR/cxY2PWUw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@chainsafe/libp2p-noise/-/libp2p-noise-8.0.1.tgz",
+			"integrity": "sha512-mr1/CMTBIfraqTY4OWBdmJ2v+0+D89vbIp1nJTHz64oDPRgU0Ah8wb7K5hgs0erU8aYMkgMtbhXeouhJK3A7wA==",
 			"requires": {
 				"@libp2p/crypto": "^1.0.0",
-				"@libp2p/interface-connection-encrypter": "^1.0.2",
+				"@libp2p/interface-connection-encrypter": "^2.0.1",
 				"@libp2p/interface-keys": "^1.0.2",
 				"@libp2p/interface-peer-id": "^1.0.2",
 				"@libp2p/logger": "^2.0.0",
-				"@libp2p/peer-collections": "^2.0.0",
 				"@libp2p/peer-id": "^1.1.8",
 				"@stablelib/chacha20poly1305": "^1.0.1",
 				"@stablelib/hkdf": "^1.0.1",
@@ -11019,38 +10650,12 @@
 				"@stablelib/x25519": "^1.0.1",
 				"it-length-prefixed": "^8.0.2",
 				"it-pair": "^2.0.2",
-				"it-pb-stream": "^2.0.1",
+				"it-pb-stream": "^2.0.2",
 				"it-pipe": "^2.0.3",
 				"it-stream-types": "^1.0.4",
-				"protons-runtime": "^2.0.1",
-				"uint8arraylist": "^2.0.0",
-				"uint8arrays": "^3.0.0"
-			},
-			"dependencies": {
-				"it-length-prefixed": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-					"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-					"requires": {
-						"err-code": "^3.0.1",
-						"it-stream-types": "^1.0.4",
-						"uint8-varint": "^1.0.1",
-						"uint8arraylist": "^2.0.0",
-						"uint8arrays": "^3.0.0"
-					}
-				},
-				"protons-runtime": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-2.0.2.tgz",
-					"integrity": "sha512-6aBGGn4scICr82Emc6+rS1qhxp9I5YUdfaR4lR10BJ6skyQxbh1vEHkrzGqQrawogwbChDrjLG8H6dI+PLh2tg==",
-					"requires": {
-						"byte-access": "^1.0.1",
-						"longbits": "^1.1.0",
-						"uint8-varint": "^1.0.2",
-						"uint8arraylist": "^2.0.0",
-						"uint8arrays": "^3.0.0"
-					}
-				}
+				"protons-runtime": "^3.1.0",
+				"uint8arraylist": "^2.3.2",
+				"uint8arrays": "^3.1.0"
 			}
 		},
 		"@coinbase/wallet-sdk": {
@@ -11524,39 +11129,25 @@
 			"integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A=="
 		},
 		"@libp2p/components": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/@libp2p/components/-/components-2.0.4.tgz",
-			"integrity": "sha512-F04yV6ZrMUEaN8YKxUe2UPsLOnDoME4aMxm+i515aYF0fIZ6qAQfCd0PERvtOnygVnIx+3i3gLsejtL5AVPGUA==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@libp2p/components/-/components-2.1.0.tgz",
+			"integrity": "sha512-9xK1pauZiptaR0eJFn1LcOr/hwosU76IjPOqTkRVZVjSStIWmBl+Njrn4qK05Jizopf0cIUnpt/8A6YWjM4D7g==",
 			"requires": {
-				"@libp2p/interface-address-manager": "^1.0.1",
+				"@libp2p/interface-address-manager": "^1.0.2",
 				"@libp2p/interface-connection": "^3.0.1",
-				"@libp2p/interface-connection-manager": "^1.0.0",
-				"@libp2p/interface-content-routing": "^1.0.0",
-				"@libp2p/interface-dht": "^1.0.0",
+				"@libp2p/interface-connection-manager": "^1.1.0",
+				"@libp2p/interface-content-routing": "^1.0.2",
+				"@libp2p/interface-dht": "^1.0.1",
 				"@libp2p/interface-metrics": "^3.0.0",
 				"@libp2p/interface-peer-id": "^1.0.2",
-				"@libp2p/interface-peer-routing": "^1.0.0",
-				"@libp2p/interface-peer-store": "^1.0.0",
-				"@libp2p/interface-pubsub": "^2.0.0",
-				"@libp2p/interface-registrar": "^2.0.0",
-				"@libp2p/interface-transport": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.2",
+				"@libp2p/interface-peer-routing": "^1.0.1",
+				"@libp2p/interface-peer-store": "^1.2.1",
+				"@libp2p/interface-pubsub": "^2.1.0",
+				"@libp2p/interface-registrar": "^2.0.3",
+				"@libp2p/interface-transport": "^1.0.3",
+				"@libp2p/interfaces": "^3.0.3",
 				"err-code": "^3.0.1",
 				"interface-datastore": "^7.0.0"
-			},
-			"dependencies": {
-				"@libp2p/interface-pubsub": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-2.0.1.tgz",
-					"integrity": "sha512-j6XSYz5Ir5yJH6KCtYMUGYlbBFfDGx/vPfFe1X3UFIC6qZ9N+IMkde6C5DCQ8calhCyM1pB2K5StAlztsZV2BQ==",
-					"requires": {
-						"@libp2p/interface-connection": "^3.0.0",
-						"@libp2p/interface-peer-id": "^1.0.0",
-						"@libp2p/interfaces": "^3.0.0",
-						"it-pushable": "^3.0.0",
-						"uint8arraylist": "^2.0.0"
-					}
-				}
 			}
 		},
 		"@libp2p/connection": {
@@ -11573,9 +11164,9 @@
 			}
 		},
 		"@libp2p/crypto": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.3.tgz",
-			"integrity": "sha512-YVoSu5eI8gAqfHcT27ovDXtQH6M4rUhV8x2w0FTyPmceU46fVt+lTsMR1woPeN8roByhjCwHjkPzGQ48Do/vwg==",
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/@libp2p/crypto/-/crypto-1.0.4.tgz",
+			"integrity": "sha512-3hHZvqi+vI8YoTHE+0u8nA5SYGPLZRLMvbgXQoAn0IyPjez66Taaxym/3p3Duf9QkFlvJu95nzpNzv0OdHs9Yw==",
 			"requires": {
 				"@libp2p/interface-keys": "^1.0.2",
 				"@noble/ed25519": "^1.6.0",
@@ -11609,22 +11200,24 @@
 			}
 		},
 		"@libp2p/interface-connection-encrypter": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-1.0.3.tgz",
-			"integrity": "sha512-3HNg52HmanRuV2rbQRMFUVTPceSqoC1+ifK9Jkqw3mbiTXXf1mdsv5uKbqts6QvNY5ABZeQWuqJb2QqibaI0mw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-2.0.1.tgz",
+			"integrity": "sha512-GtqsNJuL1q7LWX3z41t9eFFFrlLSmMH92E0rupoXeFx1dJ8Gs/Zy8b6lZro96Ld6rjU1CeZa87SmYeqQQeHRmw==",
 			"requires": {
 				"@libp2p/interface-peer-id": "^1.0.0",
-				"it-stream-types": "^1.0.4"
+				"it-stream-types": "^1.0.4",
+				"uint8arraylist": "^2.1.1"
 			}
 		},
 		"@libp2p/interface-connection-manager": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.0.3.tgz",
-			"integrity": "sha512-zDDzAKbtCkqR/3AmZ3DAoK1bt+5vhyUruV8654R9IT5PI7IBBgFnYzvkWHDI/UDvhwT27ubofPagp0m25gQZvg==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-manager/-/interface-connection-manager-1.1.0.tgz",
+			"integrity": "sha512-mkrkmFAeChwUT4Ay2fRMqGrnkytOYwAOEb4hQHzvX97hP2w4otBzZ9o3FUKtLgGqBd/bVPT/va1XJmXf6E8YTQ==",
 			"requires": {
 				"@libp2p/interface-connection": "^3.0.0",
 				"@libp2p/interface-peer-id": "^1.0.0",
-				"@libp2p/interfaces": "^3.0.0"
+				"@libp2p/interfaces": "^3.0.0",
+				"@multiformats/multiaddr": "^10.2.0"
 			}
 		},
 		"@libp2p/interface-content-routing": {
@@ -11712,27 +11305,15 @@
 			}
 		},
 		"@libp2p/interface-pubsub": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-1.0.4.tgz",
-			"integrity": "sha512-BSkt0h4fbBBHcr3LCF7fTtAoCdQBjKbTGxCa4tIJpI3m5suxC5h6OrLC2rmrexOxR9aZRkr9da4VShRyOfRLag==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-2.1.0.tgz",
+			"integrity": "sha512-X+SIqzfeCO8ZDGrFTzH9EMwMf8ojW5nk20rxv3h1sCXEdfvyJCARZ51r9UlwJcnucnHqvFChfkbubAkrr3R4Cw==",
 			"requires": {
-				"@libp2p/interface-connection": "^2.0.0",
+				"@libp2p/interface-connection": "^3.0.0",
 				"@libp2p/interface-peer-id": "^1.0.0",
 				"@libp2p/interfaces": "^3.0.0",
-				"it-pushable": "^3.0.0"
-			},
-			"dependencies": {
-				"@libp2p/interface-connection": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-2.1.1.tgz",
-					"integrity": "sha512-gjugaMsZvfo3r4tCc/yPifVQsfLogmEmJtW+eXMNiNDna3ZfmwWD9Z+KyEwuVsXKs0C4GESXei2y4SJSCEfkbA==",
-					"requires": {
-						"@libp2p/interface-peer-id": "^1.0.0",
-						"@libp2p/interfaces": "^3.0.0",
-						"@multiformats/multiaddr": "^10.2.0",
-						"it-stream-types": "^1.0.4"
-					}
-				}
+				"it-pushable": "^3.0.0",
+				"uint8arraylist": "^2.0.0"
 			}
 		},
 		"@libp2p/interface-record": {
@@ -11791,12 +11372,12 @@
 			}
 		},
 		"@libp2p/mplex": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-4.0.3.tgz",
-			"integrity": "sha512-G55n6bC4N7Biy4C6KaAlBfaOAgPFeKEspfQqKVHaUfeE4rmS156hiWCcy1YBZsGHvO7XFCt8IddCkzShStS+6w==",
+			"version": "5.2.2",
+			"resolved": "https://registry.npmjs.org/@libp2p/mplex/-/mplex-5.2.2.tgz",
+			"integrity": "sha512-e0EVsOYMiXGiOkLVsGkhg9J/7SWVWMGHhCBvEH4N+s07UEBH/fl+8wgNFyMb8SrdAD2CUP4yaULAMRgUqY4j4Q==",
 			"requires": {
 				"@libp2p/components": "^2.0.0",
-				"@libp2p/interface-connection": "^2.0.0",
+				"@libp2p/interface-connection": "^3.0.1",
 				"@libp2p/interface-stream-muxer": "^2.0.0",
 				"@libp2p/logger": "^2.0.0",
 				"@libp2p/tracked-map": "^2.0.0",
@@ -11804,24 +11385,12 @@
 				"any-signal": "^3.0.0",
 				"err-code": "^3.0.1",
 				"it-pipe": "^2.0.3",
-				"it-pushable": "^3.0.0",
+				"it-pushable": "^3.1.0",
 				"it-stream-types": "^1.0.4",
+				"rate-limiter-flexible": "^2.3.9",
 				"uint8arraylist": "^2.1.1",
 				"uint8arrays": "^3.0.0",
 				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"@libp2p/interface-connection": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-2.1.1.tgz",
-					"integrity": "sha512-gjugaMsZvfo3r4tCc/yPifVQsfLogmEmJtW+eXMNiNDna3ZfmwWD9Z+KyEwuVsXKs0C4GESXei2y4SJSCEfkbA==",
-					"requires": {
-						"@libp2p/interface-peer-id": "^1.0.0",
-						"@libp2p/interfaces": "^3.0.0",
-						"@multiformats/multiaddr": "^10.2.0",
-						"it-stream-types": "^1.0.4"
-					}
-				}
 			}
 		},
 		"@libp2p/multistream-select": {
@@ -11843,20 +11412,6 @@
 				"p-defer": "^4.0.0",
 				"uint8arraylist": "^2.3.1",
 				"uint8arrays": "^3.0.0"
-			},
-			"dependencies": {
-				"it-length-prefixed": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-					"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-					"requires": {
-						"err-code": "^3.0.1",
-						"it-stream-types": "^1.0.4",
-						"uint8-varint": "^1.0.1",
-						"uint8arraylist": "^2.0.0",
-						"uint8arrays": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@libp2p/peer-collections": {
@@ -11895,70 +11450,30 @@
 			}
 		},
 		"@libp2p/peer-record": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-2.0.2.tgz",
-			"integrity": "sha512-JkH9fBpBpGQYqDMJP3+LNtXLyjNCf0fVcBkdjyfPTSwUXTPJ5NxsluJAH+MZkkrJG9YJG22NgrZO5784GSLAaA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-4.0.2.tgz",
+			"integrity": "sha512-r1arc73ADcLd9sESNy7bDHPAsv3JYvIV7kXjB13wQJAQ1oeu9e0I6f1MAIWt4ZukNAiRD8gdlrRvNG63AAZfOg==",
 			"requires": {
 				"@libp2p/crypto": "^1.0.0",
 				"@libp2p/interface-peer-id": "^1.0.2",
-				"@libp2p/interface-record": "^1.0.1",
+				"@libp2p/interface-record": "^2.0.1",
 				"@libp2p/logger": "^2.0.0",
 				"@libp2p/peer-id": "^1.1.13",
-				"@libp2p/utils": "^2.0.0",
+				"@libp2p/utils": "^3.0.0",
 				"@multiformats/multiaddr": "^10.1.5",
 				"err-code": "^3.0.1",
-				"interface-datastore": "^6.1.0",
+				"interface-datastore": "^7.0.0",
 				"it-all": "^1.0.6",
 				"it-filter": "^1.0.3",
 				"it-foreach": "^0.1.1",
 				"it-map": "^1.0.6",
 				"it-pipe": "^2.0.3",
 				"multiformats": "^9.6.3",
-				"protons-runtime": "^1.0.4",
+				"protons-runtime": "^3.1.0",
+				"uint8-varint": "^1.0.2",
+				"uint8arraylist": "^2.1.0",
 				"uint8arrays": "^3.0.0",
 				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"@libp2p/interface-record": {
-					"version": "1.0.2",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-record/-/interface-record-1.0.2.tgz",
-					"integrity": "sha512-bYNxKtsUOsNucHeAXCZbAQxFXwR7JvoOmodwEByriMvTWYRbd6d8rm8VHZ/17QgdRFlIwNnpIPuoyyLQ8Wn1rQ==",
-					"requires": {
-						"@libp2p/interface-peer-id": "^1.0.0"
-					}
-				},
-				"interface-datastore": {
-					"version": "6.1.1",
-					"resolved": "https://registry.npmjs.org/interface-datastore/-/interface-datastore-6.1.1.tgz",
-					"integrity": "sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==",
-					"requires": {
-						"interface-store": "^2.0.2",
-						"nanoid": "^3.0.2",
-						"uint8arrays": "^3.0.0"
-					}
-				},
-				"interface-store": {
-					"version": "2.0.2",
-					"resolved": "https://registry.npmjs.org/interface-store/-/interface-store-2.0.2.tgz",
-					"integrity": "sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg=="
-				},
-				"protons-runtime": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-					"integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-					"requires": {
-						"uint8arraylist": "^1.4.0",
-						"uint8arrays": "^3.0.0"
-					}
-				},
-				"uint8arraylist": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-					"integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-					"requires": {
-						"uint8arrays": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@libp2p/peer-store": {
@@ -11988,53 +11503,6 @@
 				"protons-runtime": "^3.1.0",
 				"uint8arraylist": "^2.1.1",
 				"uint8arrays": "^3.1.0"
-			},
-			"dependencies": {
-				"@libp2p/peer-record": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-4.0.2.tgz",
-					"integrity": "sha512-r1arc73ADcLd9sESNy7bDHPAsv3JYvIV7kXjB13wQJAQ1oeu9e0I6f1MAIWt4ZukNAiRD8gdlrRvNG63AAZfOg==",
-					"requires": {
-						"@libp2p/crypto": "^1.0.0",
-						"@libp2p/interface-peer-id": "^1.0.2",
-						"@libp2p/interface-record": "^2.0.1",
-						"@libp2p/logger": "^2.0.0",
-						"@libp2p/peer-id": "^1.1.13",
-						"@libp2p/utils": "^3.0.0",
-						"@multiformats/multiaddr": "^10.1.5",
-						"err-code": "^3.0.1",
-						"interface-datastore": "^7.0.0",
-						"it-all": "^1.0.6",
-						"it-filter": "^1.0.3",
-						"it-foreach": "^0.1.1",
-						"it-map": "^1.0.6",
-						"it-pipe": "^2.0.3",
-						"multiformats": "^9.6.3",
-						"protons-runtime": "^3.1.0",
-						"uint8-varint": "^1.0.2",
-						"uint8arraylist": "^2.1.0",
-						"uint8arrays": "^3.0.0",
-						"varint": "^6.0.0"
-					}
-				},
-				"@libp2p/utils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.1.tgz",
-					"integrity": "sha512-qc1zGBb6Yrl/ihux8qmy+T3H9BymVGiZeam8b/Dr4jpHxV4mfYwySYXUxa6LZqhDp0WS2Es9B1v1UtsNRY5YxA==",
-					"requires": {
-						"@achingbrain/ip-address": "^8.1.0",
-						"@libp2p/interface-connection": "^3.0.1",
-						"@libp2p/interface-peer-store": "^1.0.0",
-						"@libp2p/logger": "^2.0.0",
-						"@multiformats/multiaddr": "^10.1.1",
-						"abortable-iterator": "^4.0.2",
-						"err-code": "^3.0.1",
-						"is-loopback-addr": "^2.0.1",
-						"it-stream-types": "^1.0.4",
-						"private-ip": "^2.1.1",
-						"uint8arraylist": "^2.3.2"
-					}
-				}
 			}
 		},
 		"@libp2p/pubsub": {
@@ -12063,32 +11531,6 @@
 				"p-queue": "^7.2.0",
 				"uint8arraylist": "^2.0.0",
 				"uint8arrays": "^3.0.0"
-			},
-			"dependencies": {
-				"@libp2p/interface-pubsub": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-2.0.1.tgz",
-					"integrity": "sha512-j6XSYz5Ir5yJH6KCtYMUGYlbBFfDGx/vPfFe1X3UFIC6qZ9N+IMkde6C5DCQ8calhCyM1pB2K5StAlztsZV2BQ==",
-					"requires": {
-						"@libp2p/interface-connection": "^3.0.0",
-						"@libp2p/interface-peer-id": "^1.0.0",
-						"@libp2p/interfaces": "^3.0.0",
-						"it-pushable": "^3.0.0",
-						"uint8arraylist": "^2.0.0"
-					}
-				},
-				"it-length-prefixed": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-					"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-					"requires": {
-						"err-code": "^3.0.1",
-						"it-stream-types": "^1.0.4",
-						"uint8-varint": "^1.0.1",
-						"uint8arraylist": "^2.0.0",
-						"uint8arrays": "^3.0.0"
-					}
-				}
 			}
 		},
 		"@libp2p/topology": {
@@ -12113,12 +11555,12 @@
 			}
 		},
 		"@libp2p/utils": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-2.0.1.tgz",
-			"integrity": "sha512-R0r9fkskuTmm5jMrlRXWpTdYJeDYcNQ1KdfSEmoVlCs5AlTeWn31+cdaHQihSEbkpEKtVCExfsZkwa3f7C1l8A==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.1.tgz",
+			"integrity": "sha512-qc1zGBb6Yrl/ihux8qmy+T3H9BymVGiZeam8b/Dr4jpHxV4mfYwySYXUxa6LZqhDp0WS2Es9B1v1UtsNRY5YxA==",
 			"requires": {
 				"@achingbrain/ip-address": "^8.1.0",
-				"@libp2p/interface-connection": "^1.0.1",
+				"@libp2p/interface-connection": "^3.0.1",
 				"@libp2p/interface-peer-store": "^1.0.0",
 				"@libp2p/logger": "^2.0.0",
 				"@multiformats/multiaddr": "^10.1.1",
@@ -12126,26 +11568,14 @@
 				"err-code": "^3.0.1",
 				"is-loopback-addr": "^2.0.1",
 				"it-stream-types": "^1.0.4",
-				"private-ip": "^2.1.1"
-			},
-			"dependencies": {
-				"@libp2p/interface-connection": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-connection/-/interface-connection-1.0.1.tgz",
-					"integrity": "sha512-4MP+RvqR5xu6EWgrebLo34HWm/X+hGXtzsCKmNfmLN9bpaYhEobzL4Rm3RYi/0ICrgAZmoU8n+x8widiuwERew==",
-					"requires": {
-						"@libp2p/interface-peer-id": "^1.0.0",
-						"@libp2p/interfaces": "^3.0.0",
-						"@multiformats/multiaddr": "^10.2.0",
-						"it-stream-types": "^1.0.4"
-					}
-				}
+				"private-ip": "^2.1.1",
+				"uint8arraylist": "^2.3.2"
 			}
 		},
 		"@libp2p/websockets": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-3.0.2.tgz",
-			"integrity": "sha512-hC8sNK7A8EkCkUaDMf56idAadoN1lteFpSsZo4GUKeYmClBpPf116tntIR4HN8SgnQ4ssPG6y9zkqGFcOtviCg==",
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/@libp2p/websockets/-/websockets-3.0.3.tgz",
+			"integrity": "sha512-fGbXpbyJaToA3Opc/lyw3C2xGlhDiabwQeQE6bTNTCpCFsBwOq8DwE4J++lkxnvJzKu0D4oC1c7oQrQ+4oq1Fw==",
 			"requires": {
 				"@libp2p/interface-connection": "^3.0.1",
 				"@libp2p/interface-transport": "^1.0.0",
@@ -12160,27 +11590,7 @@
 				"it-ws": "^5.0.0",
 				"p-defer": "^4.0.0",
 				"p-timeout": "^6.0.0",
-				"wherearewe": "^1.0.0"
-			},
-			"dependencies": {
-				"@libp2p/utils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.1.tgz",
-					"integrity": "sha512-qc1zGBb6Yrl/ihux8qmy+T3H9BymVGiZeam8b/Dr4jpHxV4mfYwySYXUxa6LZqhDp0WS2Es9B1v1UtsNRY5YxA==",
-					"requires": {
-						"@achingbrain/ip-address": "^8.1.0",
-						"@libp2p/interface-connection": "^3.0.1",
-						"@libp2p/interface-peer-store": "^1.0.0",
-						"@libp2p/logger": "^2.0.0",
-						"@multiformats/multiaddr": "^10.1.1",
-						"abortable-iterator": "^4.0.2",
-						"err-code": "^3.0.1",
-						"is-loopback-addr": "^2.0.1",
-						"it-stream-types": "^1.0.4",
-						"private-ip": "^2.1.1",
-						"uint8arraylist": "^2.3.2"
-					}
-				}
+				"wherearewe": "^2.0.1"
 			}
 		},
 		"@metamask/safe-event-emitter": {
@@ -12195,13 +11605,13 @@
 			}
 		},
 		"@multiformats/multiaddr": {
-			"version": "10.3.3",
-			"resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.3.3.tgz",
-			"integrity": "sha512-+LX9RovG7DJsANb+U6VchV/tApcdJzeafbi5+MPUam90oL91BbEh6ozNZOz4Qf5ZEeilexc12oomatmODJh1/w==",
+			"version": "10.4.3",
+			"resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-10.4.3.tgz",
+			"integrity": "sha512-yHhYKOnzvjxyF5xMwbHFI9hBi0xQIa6y0dnTlOUs+CKsJCn8NfwznCjXmW7HH0IIiFobJGgs3UNY0bWLWIrqWw==",
 			"requires": {
 				"dns-over-http-resolver": "^2.1.0",
 				"err-code": "^3.0.1",
-				"is-ip": "^4.0.0",
+				"is-ip": "^5.0.0",
 				"multiformats": "^9.4.5",
 				"uint8arrays": "^3.0.0",
 				"varint": "^6.0.0"
@@ -12216,14 +11626,14 @@
 			}
 		},
 		"@noble/ed25519": {
-			"version": "1.6.1",
-			"resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.6.1.tgz",
-			"integrity": "sha512-Gptpue6qPmg7p1E5LBO5GDtXw5WMc2DVtUmu4EQequOcoCvum1dT9sY6s9M8aSJWq9YopCN4jmTOAvqMdw3q7w=="
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
+			"integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw=="
 		},
 		"@noble/secp256k1": {
-			"version": "1.6.3",
-			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
-			"integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ=="
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.7.0.tgz",
+			"integrity": "sha512-kbacwGSsH/CTout0ZnZWxnW1B+jH/7r/WAAKLBtrRJ/+CUH7lgmQzl3GTrQua3SGKWNSDsS6lmjnDpIJ5Dxyaw=="
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.5",
@@ -12375,9 +11785,9 @@
 			}
 		},
 		"@stablelib/random": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.1.tgz",
-			"integrity": "sha512-zOh+JHX3XG9MSfIB0LZl/YwPP9w3o6WBiJkZvjPoKKu5LKFW4OLV71vMxWp9qG5T43NaWyn0QQTWgqCdO+yOBQ==",
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/@stablelib/random/-/random-1.0.2.tgz",
+			"integrity": "sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==",
 			"requires": {
 				"@stablelib/binary": "^1.0.1",
 				"@stablelib/wipe": "^1.0.1"
@@ -12399,12 +11809,12 @@
 			"integrity": "sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg=="
 		},
 		"@stablelib/x25519": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.2.tgz",
-			"integrity": "sha512-wTR0t0Bp1HABLFRbYaE3vFLuco2QbAg6QvxBnzi5j9qjhYezWHW7OiCZyaWbt25UkSaoolUUT4Il0nS/2vcbSw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@stablelib/x25519/-/x25519-1.0.3.tgz",
+			"integrity": "sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==",
 			"requires": {
 				"@stablelib/keyagreement": "^1.0.1",
-				"@stablelib/random": "^1.0.1",
+				"@stablelib/random": "^1.0.2",
 				"@stablelib/wipe": "^1.0.1"
 			}
 		},
@@ -13264,6 +12674,14 @@
 		"clone": {
 			"version": "2.1.2"
 		},
+		"clone-regexp": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-3.0.0.tgz",
+			"integrity": "sha512-ujdnoq2Kxb8s3ItNBtnYeXdm07FcU0u8ARAT1lQ2YdMwQC+cdiXX8KoqMVuglztILivceTtp4ivqGSmEmhBUJw==",
+			"requires": {
+				"is-regexp": "^3.0.0"
+			}
+		},
 		"clsx": {
 			"version": "1.2.1"
 		},
@@ -13286,6 +12704,11 @@
 		},
 		"concat-map": {
 			"version": "0.0.1"
+		},
+		"convert-hrtime": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/convert-hrtime/-/convert-hrtime-5.0.0.tgz",
+			"integrity": "sha512-lOETlkIeYSJWcbbcvjRKGxVMXJR+8+OQb/mTPbA4ObPMytYIsUbuOE0Jzy60hjARYszq1id0j8KgVhC+WGZVTg=="
 		},
 		"convert-source-map": {
 			"version": "1.8.0",
@@ -14324,6 +13747,11 @@
 		"function-bind": {
 			"version": "1.1.1"
 		},
+		"function-timeout": {
+			"version": "0.1.1",
+			"resolved": "https://registry.npmjs.org/function-timeout/-/function-timeout-0.1.1.tgz",
+			"integrity": "sha512-0NVVC0TaP7dSTvn1yMiy6d6Q8gifzbvQafO46RtLG/kHJUBNd+pVRGOBoK44wNBvtSPUJRfdVvkFdD3p0xvyZg=="
+		},
 		"function.prototype.name": {
 			"version": "1.1.5",
 			"requires": {
@@ -14657,11 +14085,12 @@
 			"version": "1.0.0"
 		},
 		"is-ip": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-4.0.0.tgz",
-			"integrity": "sha512-4B4XA2HEIm/PY+OSpeMBXr8pGWBYbXuHgjMAqrwbLO3CPTCAd9ArEJzBUKGZtk9viY6+aSfadGnWyjY3ydYZkw==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/is-ip/-/is-ip-5.0.0.tgz",
+			"integrity": "sha512-uhmKwcdWJ1nTmBdoBxdHilfJs4qdLBIvVHKRels2+UCZmfcfefuQWziadaYLpN7t/bUrJOjJHv+R1di1q7Q1HQ==",
 			"requires": {
-				"ip-regex": "^5.0.0"
+				"ip-regex": "^5.0.0",
+				"super-regex": "^0.2.0"
 			}
 		},
 		"is-loopback-addr": {
@@ -14693,6 +14122,11 @@
 				"call-bind": "^1.0.2",
 				"has-tostringtag": "^1.0.0"
 			}
+		},
+		"is-regexp": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-3.1.0.tgz",
+			"integrity": "sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA=="
 		},
 		"is-shared-array-buffer": {
 			"version": "1.0.2",
@@ -14784,24 +14218,15 @@
 			}
 		},
 		"it-length-prefixed": {
-			"version": "7.0.1",
-			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-7.0.1.tgz",
-			"integrity": "sha512-UozKoT0zZPUa0LO9OSq5KaLKPn83U7Vsy/BNAN0TUXfTI/pKrOz6RuyTSOok6NDad12FZsShBGnl9DKlfDT95g==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
+			"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
 			"requires": {
 				"err-code": "^3.0.1",
 				"it-stream-types": "^1.0.4",
-				"uint8arraylist": "^1.2.0",
-				"varint": "^6.0.0"
-			},
-			"dependencies": {
-				"uint8arraylist": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-					"integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-					"requires": {
-						"uint8arrays": "^3.0.0"
-					}
-				}
+				"uint8-varint": "^1.0.1",
+				"uint8arraylist": "^2.0.0",
+				"uint8arrays": "^3.0.0"
 			}
 		},
 		"it-map": {
@@ -14845,20 +14270,6 @@
 				"it-length-prefixed": "^8.0.2",
 				"it-stream-types": "^1.0.4",
 				"uint8arraylist": "^2.0.0"
-			},
-			"dependencies": {
-				"it-length-prefixed": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-					"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-					"requires": {
-						"err-code": "^3.0.1",
-						"it-stream-types": "^1.0.4",
-						"uint8-varint": "^1.0.1",
-						"uint8arraylist": "^2.0.0",
-						"uint8arrays": "^3.0.0"
-					}
-				}
 			}
 		},
 		"it-pipe": {
@@ -14930,56 +14341,39 @@
 			"version": "4.0.0"
 		},
 		"js-waku": {
-			"version": "0.24.0-e3bef47",
-			"resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.24.0-e3bef47.tgz",
-			"integrity": "sha512-TWZvQJuVBVDlBJfbyXBQGj5TyIXgPN3liM3PD8xDmMy9p8Fdn7KFpdjGdUho3ANLXRiOEpwCSGjO7OvFPH/87A==",
+			"version": "0.28.0",
+			"resolved": "https://registry.npmjs.org/js-waku/-/js-waku-0.28.0.tgz",
+			"integrity": "sha512-MEIFugvio2IaQMQT+g+bn24BvlJ5S4PdSKD0AGVZlR7q1BhECwlpRoytyz0A/hC1+EJWhrZB8cpIAmxwtYWTBw==",
 			"requires": {
-				"@chainsafe/libp2p-gossipsub": "^3.4.0",
-				"@chainsafe/libp2p-noise": "^7.0.1",
+				"@chainsafe/libp2p-gossipsub": "^4.1.1",
+				"@chainsafe/libp2p-noise": "^8.0.1",
 				"@ethersproject/rlp": "^5.5.0",
-				"@libp2p/crypto": "^1.0.0",
+				"@libp2p/crypto": "^1.0.4",
 				"@libp2p/interface-connection": "3.0.1",
 				"@libp2p/interface-peer-discovery": "^1.0.0",
 				"@libp2p/interface-peer-id": "^1.0.2",
 				"@libp2p/interface-peer-info": "^1.0.1",
 				"@libp2p/interface-peer-store": "^1.0.0",
+				"@libp2p/interface-pubsub": "^2.0.1",
 				"@libp2p/interfaces": "^3.0.2",
-				"@libp2p/mplex": "^4.0.1",
+				"@libp2p/mplex": "^5.1.1",
 				"@libp2p/peer-id": "^1.1.10",
-				"@libp2p/websockets": "^3.0.0",
-				"@multiformats/multiaddr": "^10.2.0",
+				"@libp2p/websockets": "^3.0.3",
+				"@multiformats/multiaddr": "^10.4.0",
 				"@noble/secp256k1": "^1.3.4",
 				"debug": "^4.3.4",
 				"dns-query": "^0.11.2",
 				"hi-base32": "^0.5.1",
 				"it-all": "^1.0.6",
-				"it-length-prefixed": "^7.0.1",
+				"it-length-prefixed": "^8.0.2",
 				"it-pipe": "^2.0.4",
 				"js-sha3": "^0.8.0",
-				"libp2p": "next",
+				"libp2p": "0.38.0",
 				"p-event": "^5.0.1",
-				"protons-runtime": "^1.0.4",
+				"protons-runtime": "^3.1.0",
+				"uint8arraylist": "^2.3.2",
 				"uint8arrays": "^3.0.0",
 				"uuid": "^8.3.2"
-			},
-			"dependencies": {
-				"protons-runtime": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/protons-runtime/-/protons-runtime-1.0.4.tgz",
-					"integrity": "sha512-DSKWjAgwaXhtYO5Jo/MrU8n/75I/P2IhxU0Fk/lSrXx6Gxl5DH+I6cHcbGAYFmAlOBmU4QRa0mvVme8VXlDeUg==",
-					"requires": {
-						"uint8arraylist": "^1.4.0",
-						"uint8arrays": "^3.0.0"
-					}
-				},
-				"uint8arraylist": {
-					"version": "1.6.0",
-					"resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-1.6.0.tgz",
-					"integrity": "sha512-QOh6SQJQj/eEqQ6NJ8SI9LH875uI2ShcOtWE3Yupci0RaHsZm4oP+mUCJzBzKkp+8gCK7M4l+6Ubvlaimt7CSw==",
-					"requires": {
-						"uint8arrays": "^3.0.0"
-					}
-				}
 			}
 		},
 		"js-yaml": {
@@ -15120,9 +14514,9 @@
 			}
 		},
 		"libp2p": {
-			"version": "0.37.3-509e56a",
-			"resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.37.3-509e56a.tgz",
-			"integrity": "sha512-iJktQPrRhrtCXMdkIUklUzX36IjR/53cHJ7BtItg2+FgXO0ZMSHvIp96JBDMDGm+GvWpbLb7AMKh0HBnLKGJ4Q==",
+			"version": "0.38.0",
+			"resolved": "https://registry.npmjs.org/libp2p/-/libp2p-0.38.0.tgz",
+			"integrity": "sha512-Wi/ptR69M5LuOrH8hwno98Dg/YeaDXmsyN2cd3vx/yuaEdcgz1RPdGtxxpyVP6J63eZbH07MYTvQcQHH5VhTkA==",
 			"requires": {
 				"@achingbrain/nat-port-mapper": "^1.0.3",
 				"@libp2p/components": "^2.0.3",
@@ -15178,7 +14572,7 @@
 				"merge-options": "^3.0.4",
 				"multiformats": "^9.6.3",
 				"mutable-proxy": "^1.0.0",
-				"node-forge": "^1.2.1",
+				"node-forge": "^1.3.1",
 				"p-fifo": "^1.0.0",
 				"p-retry": "^5.0.0",
 				"p-settle": "^5.0.0",
@@ -15192,95 +14586,6 @@
 				"uint8arrays": "^3.0.0",
 				"wherearewe": "^2.0.0",
 				"xsalsa20": "^1.1.0"
-			},
-			"dependencies": {
-				"@libp2p/interface-connection-encrypter": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-connection-encrypter/-/interface-connection-encrypter-2.0.1.tgz",
-					"integrity": "sha512-GtqsNJuL1q7LWX3z41t9eFFFrlLSmMH92E0rupoXeFx1dJ8Gs/Zy8b6lZro96Ld6rjU1CeZa87SmYeqQQeHRmw==",
-					"requires": {
-						"@libp2p/interface-peer-id": "^1.0.0",
-						"it-stream-types": "^1.0.4",
-						"uint8arraylist": "^2.1.1"
-					}
-				},
-				"@libp2p/interface-pubsub": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/interface-pubsub/-/interface-pubsub-2.0.1.tgz",
-					"integrity": "sha512-j6XSYz5Ir5yJH6KCtYMUGYlbBFfDGx/vPfFe1X3UFIC6qZ9N+IMkde6C5DCQ8calhCyM1pB2K5StAlztsZV2BQ==",
-					"requires": {
-						"@libp2p/interface-connection": "^3.0.0",
-						"@libp2p/interface-peer-id": "^1.0.0",
-						"@libp2p/interfaces": "^3.0.0",
-						"it-pushable": "^3.0.0",
-						"uint8arraylist": "^2.0.0"
-					}
-				},
-				"@libp2p/peer-record": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/@libp2p/peer-record/-/peer-record-4.0.2.tgz",
-					"integrity": "sha512-r1arc73ADcLd9sESNy7bDHPAsv3JYvIV7kXjB13wQJAQ1oeu9e0I6f1MAIWt4ZukNAiRD8gdlrRvNG63AAZfOg==",
-					"requires": {
-						"@libp2p/crypto": "^1.0.0",
-						"@libp2p/interface-peer-id": "^1.0.2",
-						"@libp2p/interface-record": "^2.0.1",
-						"@libp2p/logger": "^2.0.0",
-						"@libp2p/peer-id": "^1.1.13",
-						"@libp2p/utils": "^3.0.0",
-						"@multiformats/multiaddr": "^10.1.5",
-						"err-code": "^3.0.1",
-						"interface-datastore": "^7.0.0",
-						"it-all": "^1.0.6",
-						"it-filter": "^1.0.3",
-						"it-foreach": "^0.1.1",
-						"it-map": "^1.0.6",
-						"it-pipe": "^2.0.3",
-						"multiformats": "^9.6.3",
-						"protons-runtime": "^3.1.0",
-						"uint8-varint": "^1.0.2",
-						"uint8arraylist": "^2.1.0",
-						"uint8arrays": "^3.0.0",
-						"varint": "^6.0.0"
-					}
-				},
-				"@libp2p/utils": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/@libp2p/utils/-/utils-3.0.1.tgz",
-					"integrity": "sha512-qc1zGBb6Yrl/ihux8qmy+T3H9BymVGiZeam8b/Dr4jpHxV4mfYwySYXUxa6LZqhDp0WS2Es9B1v1UtsNRY5YxA==",
-					"requires": {
-						"@achingbrain/ip-address": "^8.1.0",
-						"@libp2p/interface-connection": "^3.0.1",
-						"@libp2p/interface-peer-store": "^1.0.0",
-						"@libp2p/logger": "^2.0.0",
-						"@multiformats/multiaddr": "^10.1.1",
-						"abortable-iterator": "^4.0.2",
-						"err-code": "^3.0.1",
-						"is-loopback-addr": "^2.0.1",
-						"it-stream-types": "^1.0.4",
-						"private-ip": "^2.1.1",
-						"uint8arraylist": "^2.3.2"
-					}
-				},
-				"it-length-prefixed": {
-					"version": "8.0.2",
-					"resolved": "https://registry.npmjs.org/it-length-prefixed/-/it-length-prefixed-8.0.2.tgz",
-					"integrity": "sha512-qYCGZ6lTaI6lcuTXUrJmVpE6clq63ULrkq1FGTxHrzexjB2cCrS/CZ5HCRDZ5IRPw33tSDUDK91S7X5S64dPyQ==",
-					"requires": {
-						"err-code": "^3.0.1",
-						"it-stream-types": "^1.0.4",
-						"uint8-varint": "^1.0.1",
-						"uint8arraylist": "^2.0.0",
-						"uint8arrays": "^3.0.0"
-					}
-				},
-				"wherearewe": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
-					"integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
-					"requires": {
-						"is-electron": "^2.2.0"
-					}
-				}
 			}
 		},
 		"lilconfig": {
@@ -15723,20 +15028,20 @@
 			"dev": true
 		},
 		"mortice": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.0.tgz",
-			"integrity": "sha512-g4rgq//2PWn4m52G6TpCSGmtWabJM8LKCZTQY4W7z0foiaQkqw+FG9a6pwIqUcTkCgBQoet8G/24V6adVMpnHw==",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/mortice/-/mortice-3.0.1.tgz",
+			"integrity": "sha512-eyDUsl1nCR9+JtNksKnaESLP9MgAXCA4w1LTtsmOSQNsThnv++f36rrBu5fC/fdGIwTJZmbiaR/QewptH93pYA==",
 			"requires": {
-				"nanoid": "^3.1.20",
+				"nanoid": "^4.0.0",
 				"observable-webworkers": "^2.0.1",
 				"p-queue": "^7.2.0",
-				"p-timeout": "^5.0.2"
+				"p-timeout": "^6.0.0"
 			},
 			"dependencies": {
-				"p-timeout": {
-					"version": "5.1.0",
-					"resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-					"integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
+				"nanoid": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-4.0.0.tgz",
+					"integrity": "sha512-IgBP8piMxe/gf73RTQx7hmnhwz0aaEXYakvqZyE302IXW3HyVNhdNGC+O2MwMAVhLEnvXlvKtGbtJf6wvHihCg=="
 				}
 			}
 		},
@@ -16509,6 +15814,11 @@
 				"safe-buffer": "^5.1.0"
 			}
 		},
+		"rate-limiter-flexible": {
+			"version": "2.3.10",
+			"resolved": "https://registry.npmjs.org/rate-limiter-flexible/-/rate-limiter-flexible-2.3.10.tgz",
+			"integrity": "sha512-bXqRBBb85WmnJemw9+xLdA7ezLXwZ+hXcOD8ZzfGMhbus4jHRrjTMXZ1kJqpKnpGu34scZc6f0qYNSxBwO7yrg=="
+		},
 		"react": {
 			"version": "18.2.0",
 			"requires": {
@@ -16831,7 +16141,9 @@
 			}
 		},
 		"sax": {
-			"version": "1.2.4"
+			"version": "1.2.4",
+			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"scheduler": {
 			"version": "0.23.0",
@@ -16953,6 +16265,11 @@
 		"split-on-first": {
 			"version": "1.1.0"
 		},
+		"sprintf-js": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+			"integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+		},
 		"stream-browserify": {
 			"version": "3.0.0",
 			"requires": {
@@ -17058,6 +16375,16 @@
 			"version": "3.1.1",
 			"dev": true
 		},
+		"super-regex": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/super-regex/-/super-regex-0.2.0.tgz",
+			"integrity": "sha512-WZzIx3rC1CvbMDloLsVw0lkZVKJWbrkJ0k1ghKFmcnPrW1+jWbgTkTEWVtD9lMdmI4jZEz40+naBxl1dCUhXXw==",
+			"requires": {
+				"clone-regexp": "^3.0.0",
+				"function-timeout": "^0.1.0",
+				"time-span": "^5.1.0"
+			}
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"requires": {
@@ -17105,6 +16432,14 @@
 		"through": {
 			"version": "2.3.8",
 			"dev": true
+		},
+		"time-span": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/time-span/-/time-span-5.1.0.tgz",
+			"integrity": "sha512-75voc/9G4rDIJleOo4jPvN4/YC4GRZrY8yy1uU4lwrB3XEQbWve8zXoO5No4eFrGcTAMYyoY67p8jRQdtA1HbA==",
+			"requires": {
+				"convert-hrtime": "^5.0.0"
+			}
 		},
 		"timeout-abort-controller": {
 			"version": "3.0.0",
@@ -17321,7 +16656,9 @@
 			"version": "1.0.2"
 		},
 		"uuid": {
-			"version": "8.3.2"
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"v8-compile-cache": {
 			"version": "2.3.0",
@@ -17383,9 +16720,9 @@
 			}
 		},
 		"wherearewe": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-1.0.2.tgz",
-			"integrity": "sha512-HyLZ7n1Yox+w1qWaFEgP/sMs5D7ka2UXmoVNaY0XzbEHLGljo4ScBchYm6cWRYNO33tmFX3Mgg4BiZkDOjihyw==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/wherearewe/-/wherearewe-2.0.1.tgz",
+			"integrity": "sha512-XUguZbDxCA2wBn2LoFtcEhXL6AXo+hVjGonwhSTTTU9SzbWG8Xu3onNIpzf9j/mYUcJQ0f+m37SzG77G851uFw==",
 			"requires": {
 				"is-electron": "^2.2.0"
 			}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"classnames": "^2.3.1",
 		"ethers": "^5.6.9",
 		"eventemitter3": "^4.0.7",
-		"js-waku": "^0.28.0",
+		"js-waku": "^0.29.0",
 		"protons-runtime": "^3.1.0",
 		"qrcode.react": "^3.1.0",
 		"react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"classnames": "^2.3.1",
 		"ethers": "^5.6.9",
 		"eventemitter3": "^4.0.7",
-		"js-waku": "^0.24.0-e3bef47",
+		"js-waku": "^0.28.0",
 		"protons-runtime": "^3.1.0",
 		"qrcode.react": "^3.1.0",
 		"react": "^18.2.0",

--- a/src/hooks/use-waku.tsx
+++ b/src/hooks/use-waku.tsx
@@ -1,6 +1,8 @@
 import { multiaddr } from '@multiformats/multiaddr'
-import { waitForRemotePeer, Waku, Protocols } from 'js-waku'
-import { createWaku, CreateOptions } from 'js-waku/lib/create_waku'
+import { Protocols } from 'js-waku'
+import { CreateOptions, createLightNode } from 'js-waku/lib/create_waku'
+import { WakuLight } from 'js-waku/lib/interfaces'
+import { waitForRemotePeer } from 'js-waku/lib/wait_for_remote_peer'
 import {
 	createContext,
 	ReactNode,
@@ -13,7 +15,7 @@ import {
 const DEFAULT_SETTINGS: CreateOptions = {}
 
 export const WakuContext = createContext<{
-	waku?: Waku
+	waku?: WakuLight
 	availableProtocols: Set<Protocols>
 	addAvailableProtocols: (protocols: Protocols[]) => void
 } | null>(null)
@@ -25,7 +27,7 @@ export const WakuProvider = ({
 	children: ReactNode
 	settings?: CreateOptions
 }) => {
-	const [waku, setWaku] = useState<Waku>()
+	const [waku, setWaku] = useState<WakuLight>()
 	const [availableProtocols, setAvailableProtocols] = useState<Set<Protocols>>(
 		new Set()
 	)
@@ -36,7 +38,7 @@ export const WakuProvider = ({
 	useEffect(() => {
 		// eslint-disable-next-line @typescript-eslint/no-extra-semi
 		;(async () => {
-			const waku = await createWaku(settings || DEFAULT_SETTINGS)
+			const waku = await createLightNode(settings || DEFAULT_SETTINGS)
 			setWaku(waku)
 
 			await waku.start()
@@ -77,7 +79,7 @@ export const useWaku = (protocols?: Protocols[]) => {
 		}
 
 		if (!protocols) {
-			protocols = [Protocols.Relay]
+			protocols = [Protocols.LightPush]
 		}
 
 		// If all protocols are available, we're good

--- a/src/pages/marketplaces/services/marketplace-items.tsx
+++ b/src/pages/marketplaces/services/marketplace-items.tsx
@@ -128,7 +128,7 @@ export const useGetWakuItems = (marketplace: string) => {
 		}
 
 		const decoded = await decodeWakuMessage(message as WakuMessageWithPayload)
-		if (decoded) {
+		if (!decoded) {
 			return
 		}
 

--- a/src/services/profile-picture.ts
+++ b/src/services/profile-picture.ts
@@ -1,4 +1,5 @@
 import { useMemo } from 'react'
+import { MessageV0 } from 'js-waku/lib/waku_message/version_0'
 
 // Types
 import type { WakuLight } from 'js-waku/lib/interfaces'
@@ -7,11 +8,7 @@ import type { WakuLight } from 'js-waku/lib/interfaces'
 import { ProfilePicture } from '../protos/profile-picture'
 
 // Services
-import {
-	postWakuMessage,
-	useLatestTopicData,
-	WakuMessageWithPayload,
-} from './waku'
+import { postWakuMessage, useLatestTopicData, WithPayload } from './waku'
 
 // Lib
 import { bufferToHex } from '../lib/tools'
@@ -46,7 +43,7 @@ export const createProfilePicture = async (
 }
 
 const decodeMessage = (
-	message: WakuMessageWithPayload
+	message: WithPayload<MessageV0>
 ): ProfilePicture | false => {
 	try {
 		return ProfilePicture.decode(message.payload)

--- a/src/services/profile-picture.ts
+++ b/src/services/profile-picture.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
 
 // Types
-import type { Waku } from 'js-waku'
+import type { WakuLight } from 'js-waku/lib/interfaces'
 
 // Protos
 import { ProfilePicture } from '../protos/profile-picture'
@@ -28,7 +28,7 @@ export const getProfilePictureTopic = (hash: string) => {
 }
 
 export const createProfilePicture = async (
-	waku: Waku,
+	waku: WakuLight,
 	{ dataUri }: CreateProfilePicture
 ) => {
 	const blob = await (await fetch(dataUri)).blob()

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -1,6 +1,7 @@
 import { useEffect } from 'react'
 import { useAccount } from 'wagmi'
 import { getAddress } from '@ethersproject/address'
+import { MessageV0 } from 'js-waku/lib/waku_message/version_0'
 
 // Store
 import { setStore, useStore } from '../store'
@@ -14,11 +15,7 @@ import type { Profile } from '../types'
 import { Profile as ProfileProto } from '../protos/profile'
 
 // Services
-import {
-	postWakuMessage,
-	useLatestTopicData,
-	WakuMessageWithPayload,
-} from './waku'
+import { postWakuMessage, useLatestTopicData, WithPayload } from './waku'
 import { createSignedProto, decodeSignedPayload, EIP712Config } from './eip-712'
 import { createProfilePicture } from './profile-picture'
 
@@ -72,7 +69,7 @@ export const createProfile = async (
 }
 
 const decodeMessage = (
-	message: WakuMessageWithPayload
+	message: WithPayload<MessageV0>
 ): ProfileProto | false => {
 	return decodeSignedPayload(
 		eip712Config,

--- a/src/services/profile.ts
+++ b/src/services/profile.ts
@@ -6,7 +6,7 @@ import { getAddress } from '@ethersproject/address'
 import { setStore, useStore } from '../store'
 
 // Types
-import { Protocols, Waku } from 'js-waku'
+import { Protocols } from 'js-waku'
 import type { Signer } from 'ethers'
 import type { Profile } from '../types'
 
@@ -24,6 +24,7 @@ import { createProfilePicture } from './profile-picture'
 
 // Hooks
 import { useWaku } from '../hooks/use-waku'
+import { WakuLight } from 'js-waku/lib/interfaces'
 
 type CreateProfile = {
 	username: string
@@ -53,7 +54,7 @@ export const getProfileTopic = (address?: string) => {
 }
 
 export const createProfile = async (
-	waku: Waku,
+	waku: WakuLight,
 	connector: { getSigner: () => Promise<Signer> },
 	input: CreateProfile
 ) => {
@@ -92,7 +93,7 @@ export const useProfile = (address?: string) => {
 	return { ...state, profile: data }
 }
 
-const postPicture = async (waku: Waku, dataUri?: string) => {
+const postPicture = async (waku: WakuLight, dataUri?: string) => {
 	if (!dataUri) {
 		return
 	}
@@ -103,7 +104,7 @@ const postPicture = async (waku: Waku, dataUri?: string) => {
 
 // TODO: Fix teaful issues
 const updateProfile = async (
-	waku: Waku,
+	waku: WakuLight,
 	connector: { getSigner: () => Promise<Signer> },
 	profile: Profile
 ) => {
@@ -121,7 +122,7 @@ const updateProfile = async (
 }
 
 export const useSyncProfile = () => {
-	const { waku, waiting } = useWaku([Protocols.Relay])
+	const { waku, waiting } = useWaku([Protocols.LightPush])
 	const { address, connector } = useAccount()
 	const [profile] = useStore.profile()
 	const {

--- a/src/services/select-provider.ts
+++ b/src/services/select-provider.ts
@@ -1,5 +1,6 @@
 import { arrayify, hexlify } from '@ethersproject/bytes'
 import { getAddress } from '@ethersproject/address'
+import { MessageV0 } from 'js-waku/lib/waku_message/version_0'
 
 // Types
 import type { WakuLight } from 'js-waku/lib/interfaces'
@@ -9,11 +10,7 @@ import type { Signer } from 'ethers'
 import { SelectProvider } from '../protos/select-provider'
 
 // Services
-import {
-	postWakuMessage,
-	useLatestTopicData,
-	WakuMessageWithPayload,
-} from './waku'
+import { postWakuMessage, useLatestTopicData, WithPayload } from './waku'
 import { createSignedProto, decodeSignedPayload, EIP712Config } from './eip-712'
 
 type Marketplace = {
@@ -102,7 +99,7 @@ export const createSelectProvider = async (
 }
 
 const decodeMessage = (
-	message: WakuMessageWithPayload
+	message: WithPayload<MessageV0>
 ): SelectProvider | false => {
 	return decodeSignedPayload(
 		(decoded) =>

--- a/src/services/select-provider.ts
+++ b/src/services/select-provider.ts
@@ -2,7 +2,7 @@ import { arrayify, hexlify } from '@ethersproject/bytes'
 import { getAddress } from '@ethersproject/address'
 
 // Types
-import type { Waku } from 'js-waku'
+import type { WakuLight } from 'js-waku/lib/interfaces'
 import type { Signer } from 'ethers'
 
 // Protos
@@ -67,7 +67,7 @@ const toArray = <Condition extends boolean>(
 }
 
 export const createSelectProvider = async (
-	waku: Waku,
+	waku: WakuLight,
 	signer: Signer,
 	data: CreateSelectProvider
 ) => {

--- a/src/services/waku.ts
+++ b/src/services/waku.ts
@@ -65,7 +65,7 @@ export const useWakuStoreQuery = (
 	options: QueryOptions = {}
 ) => {
 	return useWakuStore(
-		(waku: WakuLight) => waku.store.queryCallbackOnPromise,
+		(waku: WakuLight) => waku.store.queryCallbackOnPromise.bind(waku.store),
 		callback,
 		getTopic,
 		dependencies,
@@ -80,7 +80,7 @@ export const useWakuStoreQueryOrdered = (
 	options: QueryOptions = {}
 ) => {
 	return useWakuStore(
-		(waku: WakuLight) => waku.store.queryOrderedCallback,
+		(waku: WakuLight) => waku.store.queryOrderedCallback.bind(waku.store),
 		callback,
 		getTopic,
 		dependencies,

--- a/src/services/waku.ts
+++ b/src/services/waku.ts
@@ -64,7 +64,7 @@ export const useWakuStore = <Msg extends Message, Callback>(
 
 export const useWakuStoreQuery = <Msg extends Message>(
 	decoders: Decoder<Msg>[],
-	_callback: (
+	callback: (
 		message: Promise<Msg | undefined>
 	) => Promise<void | boolean> | boolean | void,
 	dependencies: DependencyList,
@@ -73,7 +73,7 @@ export const useWakuStoreQuery = <Msg extends Message>(
 	return useWakuStore<Msg, Promise<Msg | undefined>>(
 		(waku: WakuLight) => waku.store.queryCallbackOnPromise.bind(waku.store),
 		decoders,
-		_callback,
+		callback,
 		dependencies,
 		options
 	)
@@ -81,14 +81,14 @@ export const useWakuStoreQuery = <Msg extends Message>(
 
 export const useWakuStoreQueryOrdered = <Msg extends Message>(
 	decoders: Decoder<Msg>[],
-	_callback: (message: Msg) => Promise<void | boolean> | boolean | void,
+	callback: (message: Msg) => Promise<void | boolean> | boolean | void,
 	dependencies: DependencyList,
 	options: QueryOptions = {}
 ) => {
 	return useWakuStore<Msg, Msg>(
 		(waku: WakuLight) => waku.store.queryOrderedCallback.bind(waku.store),
 		decoders,
-		_callback,
+		callback,
 		dependencies,
 		options
 	)


### PR DESCRIPTION
Required updating our `nim-waku` nodes (to `statusteam/nim-waku:v0.12.0`), as the new `createLightNode` doesn't support `v0.11` (https://github.com/status-im/nwaku/issues/1085).

There's still a blocker: https://github.com/status-im/nwaku/issues/1157

However, using the SQLite store fixed that issue for the time being: `--sqlite-store:true --sqlite-retention-time:31536000`.