### PR TITLE
feat: add text that show different provider was already selected

### DIFF
--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -511,16 +511,16 @@ export const MarketplaceItem = () => {
 					: undefined),
 			replies: replies,
 			seeker: {
-				id: item?.owner,
+				address: item?.owner,
 				reputation: item?.seekerRep,
 			},
 			provider: {
-				id: chainItem.item?.providerAddress,
+				address: chainItem.item?.providerAddress,
 				reputation: chainItem.item?.providerRep,
 			},
 		},
 		user: {
-			id: address,
+			address,
 		},
 	}
 
@@ -631,7 +631,7 @@ export const MarketplaceItem = () => {
 						repliesCount={store.request.replies.length}
 						amount={formatMoney(store.request.price || 0n)}
 						user={{
-							name: store.request.seeker.id || '',
+							name: store.request.seeker.address || '',
 							reputation: store.request.seeker.reputation?.toNumber() || 0,
 						}}
 					/>
@@ -647,80 +647,111 @@ export const MarketplaceItem = () => {
 					}}
 				>
 					<>
-						{store.request.selectedReply &&
-						(store.request.selectedReply?.user.address === store.user.id ||
-							store.request.seeker.id === store.user.id) ? (
+						{store.request.selectedReply ? (
 							<>
-								{status === Status.Open && !selectedProvider.data && (
-									<div
-										style={{
-											backgroundColor: getColor('white'),
-											borderRadius: '50%',
-											width: 37,
-											height: 37,
-											boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.25)',
-											display: 'flex',
-											alignItems: 'center',
-											justifyContent: 'center',
-											cursor: 'pointer',
-											marginLeft: 30,
-											marginTop: 30,
-										}}
-									>
-										<IconButton
-											variant="back"
-											onClick={() => setSelectedReply(undefined)}
-										/>
-									</div>
-								)}
+								{(store.request.selectedReply?.user.address ===
+									store.user.address ||
+									store.request.seeker.address === store.user.address) && (
+									<>
+										{status === Status.Open && !selectedProvider.data && (
+											<div
+												style={{
+													backgroundColor: getColor('white'),
+													borderRadius: '50%',
+													width: 37,
+													height: 37,
+													boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.25)',
+													display: 'flex',
+													alignItems: 'center',
+													justifyContent: 'center',
+													cursor: 'pointer',
+													marginLeft: 30,
+													marginTop: 30,
+												}}
+											>
+												<IconButton
+													variant="back"
+													onClick={() => setSelectedReply(undefined)}
+												/>
+											</div>
+										)}
 
-								<ReplyUI selected reply={store.request.selectedReply} />
-								{/* Show select provider button */}
-								{status === Status.Open && !selectedProvider.data && (
-									<div
-										style={{
-											padding: 30,
-											backgroundColor: getColor('white'),
-											width: '100%',
-										}}
-									>
-										<Button
-											size="large"
-											onClick={selectProvider}
-											disabled={loadingSelectProvider}
-										>
-											select {formatName(store.request.selectedReply.user)}
-										</Button>
-									</div>
-								)}
+										<ReplyUI selected reply={store.request.selectedReply} />
+										{/* Show select provider button */}
+										{status === Status.Open && !selectedProvider.data && (
+											<div
+												style={{
+													padding: 30,
+													backgroundColor: getColor('white'),
+													width: '100%',
+												}}
+											>
+												<Button
+													size="large"
+													onClick={selectProvider}
+													disabled={loadingSelectProvider}
+												>
+													select {formatName(store.request.selectedReply.user)}
+												</Button>
+											</div>
+										)}
 
-								{status === Status.Open &&
-									store.request.seeker.id === store.user.id &&
-									selectedProvider.data && (
-										<div
-											style={{
-												backgroundColor: getColor('blue'),
-												padding: 30,
-												display: 'flex',
-												flexDirection: 'column',
-												alignItems: 'center',
-												justifyContent: 'center',
-												textAlign: 'center',
-											}}
-										>
-											<Typography variant="body-bold-16" color="white">
-												You selected{' '}
-												{formatName(store.request.selectedReply.user)} to make a
-												deal.
-											</Typography>
-											<Typography variant="small-light-12" color="white">
-												Waiting for{' '}
-												{formatName(store.request.selectedReply.user)} to
-												respond
-											</Typography>
-											<Button style={{ marginTop: 30 }} size="large">
-												unselect {formatName(store.request.selectedReply.user)}
-											</Button>
+										{status === Status.Open &&
+											store.request.seeker.address === store.user.address &&
+											selectedProvider.data && (
+												<div
+													style={{
+														backgroundColor: getColor('blue'),
+														padding: 30,
+														display: 'flex',
+														flexDirection: 'column',
+														alignItems: 'center',
+														justifyContent: 'center',
+														textAlign: 'center',
+													}}
+												>
+													<Typography variant="body-bold-16" color="white">
+														You selected{' '}
+														{formatName(store.request.selectedReply.user)} to
+														make a deal.
+													</Typography>
+													<Typography variant="small-light-12" color="white">
+														Waiting for{' '}
+														{formatName(store.request.selectedReply.user)} to
+														respond
+													</Typography>
+													<Button style={{ marginTop: 30 }} size="large">
+														unselect{' '}
+														{formatName(store.request.selectedReply.user)}
+													</Button>
+												</div>
+											)}
+									</>
+								)}
+								{store.request.selectedReply?.user.address !==
+									store.user.address &&
+									store.request.seeker.address !== store.user.address && (
+										<div style={{ padding: 30, textAlign: 'center' }}>
+											{store.request.myReply && (
+												<>
+													<Typography variant="body-light-16">
+														{store.request.seeker.address} selected
+													</Typography>{' '}
+													<Typography variant="body-bold-16">
+														a different provider.
+													</Typography>
+												</>
+											)}
+											{!store.request.myReply && (
+												<>
+													<Typography variant="body-light-16">
+														{store.request.seeker.address} already selected
+													</Typography>{' '}
+													<Typography variant="body-bold-16">
+														a provider.
+													</Typography>
+												</>
+											)}
 										</div>
 									)}
 							</>
@@ -732,8 +763,10 @@ export const MarketplaceItem = () => {
 											<ReplyContainer
 												key={reply.signature}
 												reply={reply}
-												isMyRequest={store.request.seeker.id === store.user.id}
-												isMyReply={reply.from === store.user.id}
+												isMyRequest={
+													store.request.seeker.address === store.user.address
+												}
+												isMyReply={reply.from === store.user.address}
 												amount={formatMoney(store.request.price ?? 0n)}
 												status={status}
 												setSelectedReply={setSelectedReply}
@@ -780,7 +813,7 @@ export const MarketplaceItem = () => {
 									marketplace={id}
 									item={itemId}
 									amount={formatMoney(store.request.price ?? 0n)}
-									user={store.request.seeker.id ?? 'unknown'}
+									user={store.request.seeker.address ?? 'unknown'}
 								/>
 							)}
 					</>

--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -549,6 +549,7 @@ export const MarketplaceItem = () => {
 		})
 
 		setLoadingSelectProvider(false)
+		location.reload()
 	}
 
 	if (!item || !chainItem.item) {
@@ -586,6 +587,11 @@ export const MarketplaceItem = () => {
 	}
 
 	const { status } = chainItem.item
+
+	const isSelectedReplyMyReply =
+		store.request.selectedReply?.user.address === store.user.address
+	const isMyRequest = store.request.seeker.address === store.user.address
+	const showSelectProviderBtn = status === Status.Open && !selectedProvider.data
 
 	return (
 		<Container>
@@ -646,179 +652,166 @@ export const MarketplaceItem = () => {
 						marginRight: 10,
 					}}
 				>
-					<>
-						{store.request.selectedReply ? (
+					{store.request.selectedReply &&
+						(isSelectedReplyMyReply || isMyRequest) && (
 							<>
-								{(store.request.selectedReply?.user.address ===
-									store.user.address ||
-									store.request.seeker.address === store.user.address) && (
-									<>
-										{status === Status.Open && !selectedProvider.data && (
-											<div
-												style={{
-													backgroundColor: getColor('white'),
-													borderRadius: '50%',
-													width: 37,
-													height: 37,
-													boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.25)',
-													display: 'flex',
-													alignItems: 'center',
-													justifyContent: 'center',
-													cursor: 'pointer',
-													marginLeft: 30,
-													marginTop: 30,
-												}}
-											>
-												<IconButton
-													variant="back"
-													onClick={() => setSelectedReply(undefined)}
-												/>
-											</div>
-										)}
-
-										<ReplyUI selected reply={store.request.selectedReply} />
-										{/* Show select provider button */}
-										{status === Status.Open && !selectedProvider.data && (
-											<div
-												style={{
-													padding: 30,
-													backgroundColor: getColor('white'),
-													width: '100%',
-												}}
-											>
-												<Button
-													size="large"
-													onClick={selectProvider}
-													disabled={loadingSelectProvider}
-												>
-													select {formatName(store.request.selectedReply.user)}
-												</Button>
-											</div>
-										)}
-
-										{status === Status.Open &&
-											store.request.seeker.address === store.user.address &&
-											selectedProvider.data && (
-												<div
-													style={{
-														backgroundColor: getColor('blue'),
-														padding: 30,
-														display: 'flex',
-														flexDirection: 'column',
-														alignItems: 'center',
-														justifyContent: 'center',
-														textAlign: 'center',
-													}}
-												>
-													<Typography variant="body-bold-16" color="white">
-														You selected{' '}
-														{formatName(store.request.selectedReply.user)} to
-														make a deal.
-													</Typography>
-													<Typography variant="small-light-12" color="white">
-														Waiting for{' '}
-														{formatName(store.request.selectedReply.user)} to
-														respond
-													</Typography>
-													<Button style={{ marginTop: 30 }} size="large">
-														unselect{' '}
-														{formatName(store.request.selectedReply.user)}
-													</Button>
-												</div>
-											)}
-									</>
+								{showSelectProviderBtn && (
+									<div
+										style={{
+											backgroundColor: getColor('white'),
+											borderRadius: '50%',
+											width: 37,
+											height: 37,
+											boxShadow: '0px 1px 2px rgba(0, 0, 0, 0.25)',
+											display: 'flex',
+											alignItems: 'center',
+											justifyContent: 'center',
+											cursor: 'pointer',
+											marginLeft: 30,
+											marginTop: 30,
+										}}
+									>
+										<IconButton
+											variant="back"
+											onClick={() => setSelectedReply(undefined)}
+										/>
+									</div>
 								)}
-								{store.request.selectedReply?.user.address !==
-									store.user.address &&
-									store.request.seeker.address !== store.user.address && (
-										<div style={{ padding: 30, textAlign: 'center' }}>
-											{store.request.myReply && (
-												<>
-													<Typography variant="body-light-16">
-														{store.request.seeker.address} selected
-													</Typography>{' '}
-													<Typography variant="body-bold-16">
-														a different provider.
-													</Typography>
-												</>
-											)}
-											{!store.request.myReply && (
-												<>
-													<Typography variant="body-light-16">
-														{store.request.seeker.address} already selected
-													</Typography>{' '}
-													<Typography variant="body-bold-16">
-														a provider.
-													</Typography>
-												</>
-											)}
+
+								<ReplyUI selected reply={store.request.selectedReply} />
+
+								{/* Show select provider button */}
+								{showSelectProviderBtn && (
+									<div
+										style={{
+											padding: 30,
+											backgroundColor: getColor('white'),
+											width: '100%',
+										}}
+									>
+										<Button
+											size="large"
+											onClick={selectProvider}
+											disabled={loadingSelectProvider}
+										>
+											select {formatName(store.request.selectedReply.user)}
+										</Button>
+									</div>
+								)}
+
+								{status === Status.Open &&
+									isMyRequest &&
+									selectedProvider.data && (
+										<div
+											style={{
+												backgroundColor: getColor('blue'),
+												padding: 30,
+												display: 'flex',
+												flexDirection: 'column',
+												alignItems: 'center',
+												justifyContent: 'center',
+												textAlign: 'center',
+											}}
+										>
+											<Typography variant="body-bold-16" color="white">
+												You selected{' '}
+												{formatName(store.request.selectedReply.user)} to make a
+												deal.
+											</Typography>
+											<Typography variant="small-light-12" color="white">
+												Waiting for{' '}
+												{formatName(store.request.selectedReply.user)} to
+												respond
+											</Typography>
+											<Button style={{ marginTop: 30 }} size="large">
+												unselect {formatName(store.request.selectedReply.user)}
+											</Button>
 										</div>
 									)}
 							</>
-						) : (
+						)}
+
+					{status !== Status.Open && !isSelectedReplyMyReply && !isMyRequest && (
+						<div style={{ padding: 30, textAlign: 'center' }}>
+							{store.request.myReply && (
+								<>
+									<Typography variant="body-light-16">
+										{store.request.seeker.address} selected
+									</Typography>{' '}
+									<Typography variant="body-bold-16">
+										a different provider.
+									</Typography>
+								</>
+							)}
+							{!store.request.myReply && (
+								<>
+									<Typography variant="body-light-16">
+										{store.request.seeker.address} already selected
+									</Typography>{' '}
+									<Typography variant="body-bold-16">a provider.</Typography>
+								</>
+							)}
+						</div>
+					)}
+
+					{status === Status.Open &&
+						!isSelectedReplyMyReply &&
+						replies.length > 0 && (
 							<>
-								{replies.length > 0 && (
-									<>
-										{store.request.replies.map((reply) => (
-											<ReplyContainer
-												key={reply.signature}
-												reply={reply}
-												isMyRequest={
-													store.request.seeker.address === store.user.address
-												}
-												isMyReply={reply.from === store.user.address}
-												amount={formatMoney(store.request.price ?? 0n)}
-												status={status}
-												setSelectedReply={setSelectedReply}
-											/>
-										))}
-									</>
-								)}
-								{replies.length === 0 && !isReplying && (
-									<div style={{ padding: 30, textAlign: 'center' }}>
-										<Typography
-											variant="small-light-12"
-											color="grey2-light-text"
-										>
-											No replies yet.
-										</Typography>
-									</div>
-								)}
+								{store.request.replies.map((reply) => (
+									<ReplyContainer
+										key={reply.signature}
+										reply={reply}
+										isMyRequest={
+											store.request.seeker.address === store.user.address
+										}
+										isMyReply={reply.from === store.user.address}
+										amount={formatMoney(store.request.price ?? 0n)}
+										status={status}
+										setSelectedReply={setSelectedReply}
+									/>
+								))}
 							</>
 						)}
 
-						{status === Status.Open && item.owner !== address && isReplying && (
-							<div style={{ marginLeft: 30, marginRight: 0, marginBottom: 30 }}>
-								<ReplyForm
-									item={item}
-									marketplace={id}
-									decimals={decimals}
-									onCancel={() => setIsReplying(false)}
-								/>
-							</div>
-						)}
+					{!store.request.selectedReply && replies.length === 0 && !isReplying && (
+						<div style={{ padding: 30, textAlign: 'center' }}>
+							<Typography variant="small-light-12" color="grey2-light-text">
+								No replies yet.
+							</Typography>
+						</div>
+					)}
 
-						{provider === address && status === Status.Open && (
-							<FundDeal
+					{status === Status.Open && !isMyRequest && isReplying && (
+						<div style={{ marginLeft: 30, marginRight: 0, marginBottom: 30 }}>
+							<ReplyForm
+								item={item}
 								marketplace={id}
-								item={itemId}
-								data={selectedProvider.data}
-								amount={formatMoney(store.request.price ?? 0n)}
-								fee={formatMoney(store.request.fee?.toBigInt() ?? 0n)}
+								decimals={decimals}
+								onCancel={() => setIsReplying(false)}
 							/>
-						)}
-						{chainItem.item.seekerAddress === address &&
-							status === Status.Funded && (
-								<PayoutItem
-									marketplace={id}
-									item={itemId}
-									amount={formatMoney(store.request.price ?? 0n)}
-									user={store.request.seeker.address ?? 'unknown'}
-								/>
-							)}
-					</>
+						</div>
+					)}
+
+					{isSelectedReplyMyReply && status === Status.Open && (
+						<FundDeal
+							marketplace={id}
+							item={itemId}
+							data={selectedProvider.data}
+							amount={formatMoney(store.request.price ?? 0n)}
+							fee={formatMoney(store.request.fee?.toBigInt() ?? 0n)}
+						/>
+					)}
+					{isMyRequest && status === Status.Funded && (
+						<PayoutItem
+							marketplace={id}
+							item={itemId}
+							amount={formatMoney(store.request.price ?? 0n)}
+							user={store.request.seeker.address ?? 'unknown'}
+						/>
+					)}
 					{status === Status.Open &&
-						item.owner !== address &&
+						!isMyRequest &&
 						!isReplying &&
 						!store.request.myReply && (
 							<div
@@ -838,7 +831,7 @@ export const MarketplaceItem = () => {
 						)}
 				</div>
 
-				{status === Status.Open && item.owner === address && (
+				{isMyRequest && status === Status.Open && (
 					<div
 						style={{ marginTop: 58, display: 'flex', justifyContent: 'center' }}
 					>
@@ -847,7 +840,7 @@ export const MarketplaceItem = () => {
 						</Button>
 					</div>
 				)}
-				{chainItem.item.seekerAddress === address && status === Status.Funded && (
+				{isMyRequest && status === Status.Funded && (
 					<div
 						style={{ marginTop: 40, display: 'flex', justifyContent: 'center' }}
 					>

--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -756,6 +756,7 @@ export const MarketplaceItem = () => {
 
 					{status === Status.Open &&
 						!isSelectedReplyMyReply &&
+						!isMyRequest &&
 						replies.length > 0 && (
 							<>
 								{store.request.replies.map((reply) => (

--- a/src/ui/typography.tsx
+++ b/src/ui/typography.tsx
@@ -188,6 +188,24 @@ export function Typography({
 					{children}
 				</span>
 			)
+
+		case 'body-light-16':
+			return (
+				<span
+					style={{
+						fontFamily: 'Montserrat',
+						fontStyle: 'normal',
+						fontWeight: 300,
+						fontSize: 16,
+						color,
+						textAlign,
+						...style,
+					}}
+					{...props}
+				>
+					{children}
+				</span>
+			)
 		case 'small-bold-12':
 			return (
 				<span


### PR DESCRIPTION
Resolves #66, resolves #67

TODO:
- [x] this should only be visible once the state of the request is `funded`

![Screenshot 2022-10-04 at 19 29 59](https://user-images.githubusercontent.com/7974813/193886789-e208c7bc-db55-4631-a69f-ec3aadd19f4a.png)

![Screenshot 2022-10-04 at 19 53 16](https://user-images.githubusercontent.com/7974813/193891050-ded6c802-98c7-47ad-bd5e-0f5eba8acdd8.png)

