### PR TITLE
fix: `useLatestTopicData`

### DIFF
--- a/src/services/waku.ts
+++ b/src/services/waku.ts
@@ -121,7 +121,12 @@ export const useLatestTopicData = <Data>(
 	const [data, setData] = useState<Data>()
 	const [payload, setPayload] = useState<Uint8Array>()
 
-	const callback = (message: MessageV0) => {
+	const callback = async (msg: Promise<MessageV0 | undefined>) => {
+		const message = await msg
+		if (!message) {
+			return
+		}
+
 		const data = decodeMessage(message as WithPayload<MessageV0>)
 		if (data) {
 			setData(data)
@@ -131,15 +136,10 @@ export const useLatestTopicData = <Data>(
 		}
 	}
 
-	const state = useWakuStoreQueryOrdered(
-		[new DecoderV0(topic)],
-		callback,
-		[topic],
-		{
-			pageDirection: PageDirection.BACKWARD,
-			pageSize: 1,
-		}
-	)
+	const state = useWakuStoreQuery([new DecoderV0(topic)], callback, [topic], {
+		pageDirection: PageDirection.BACKWARD,
+		pageSize: 1,
+	})
 
 	return { ...state, lastUpdate, data, payload }
 }


### PR DESCRIPTION
It seems like `queryOrderedCallback` has a bug right now where it cannot be aborted ([source code](https://github.com/waku-org/js-waku/blob/29436eaf/src/lib/waku_store/index.ts#L108-L137)). This is a temporary fix to get Boardwalk up and running again in the meanwhile.

I haven't filed an issue yet, waiting for confirmation: https://discord.com/channels/864066763682218004/865466694554484738/1031216010906320896

Related: https://github.com/waku-org/js-waku/issues/978