### PR TITLE
fix: select provider name and reputation

### DIFF
--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -548,14 +548,16 @@ export const MarketplaceItem = () => {
 			status: chainItem.item?.status,
 			fee: item?.fee,
 			myReply: replies.find((r) => r.from === address),
-			selectedReply: selectedReplyItemClean && {
-				text: selectedReplyItemClean.text,
-				date: new Date(),
-				amount: tokenToDecimals(item?.price || 0n),
-				isMyReply: address === selectedReplyItemClean.from,
-				user: selectedProviderUser,
-				tokenName,
-			},
+			selectedReply:
+				selectedReplyItemClean &&
+				({
+					text: selectedReplyItemClean.text,
+					date: new Date(),
+					amount: tokenToDecimals(item?.price || 0n),
+					isMyReply: address === selectedReplyItemClean.from,
+					user: selectedProviderUser,
+					tokenName,
+				} as Reply), // FIXME: this should not be typecasted
 			replies: replies,
 			seeker,
 			provider: providerUser,
@@ -660,7 +662,7 @@ export const MarketplaceItem = () => {
 
 	const isSelectedReplyMyReply =
 		store.user?.address &&
-		store.request.selectedReply?.user.address === store.user?.address
+		store.request.selectedReply?.user?.address === store.user?.address
 	const isMyRequest =
 		store.user?.address && store.request.seeker?.address === store.user?.address
 	const showSelectProviderBtn = status === Status.Open && !selectedProvider.data

--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -548,18 +548,14 @@ export const MarketplaceItem = () => {
 			status: chainItem.item?.status,
 			fee: item?.fee,
 			myReply: replies.find((r) => r.from === address),
-			selectedReply:
-				selectedReply ??
-				(selectedReplyItemClean !== undefined
-					? ({
-							text: selectedReplyItemClean.text,
-							date: new Date(),
-							amount: tokenToDecimals(item?.price || 0n),
-							isMyReply: address === selectedReplyItemClean.from,
-							user: selectedProviderUser,
-							tokenName,
-					  } as Reply)
-					: undefined),
+			selectedReply: selectedReplyItemClean && {
+				text: selectedReplyItemClean.text,
+				date: new Date(),
+				amount: tokenToDecimals(item?.price || 0n),
+				isMyReply: address === selectedReplyItemClean.from,
+				user: selectedProviderUser,
+				tokenName,
+			},
 			replies: replies,
 			seeker,
 			provider: providerUser,

--- a/src/pages/marketplaces/services/marketplace.ts
+++ b/src/pages/marketplaces/services/marketplace.ts
@@ -202,7 +202,7 @@ export const useMarketplaceItem = (marketplace: string, itemId: bigint) => {
 
 export const useMarketplaceSeekerReputation = (
 	marketplace: string,
-	user: string
+	user?: string
 ) => {
 	const config = useMarketplaceConfig(marketplace, ['seekerRep'])
 	return useReputation(config?.seekerRep, user)
@@ -210,7 +210,7 @@ export const useMarketplaceSeekerReputation = (
 
 export const useMarketplaceProviderReputation = (
 	marketplace: string,
-	user: string
+	user?: string
 ) => {
 	const config = useMarketplaceConfig(marketplace, ['providerRep'])
 	return useReputation(config?.providerRep, user)

--- a/src/services/reputation.ts
+++ b/src/services/reputation.ts
@@ -3,7 +3,7 @@ import { Contract } from 'ethers'
 import { useProvider } from 'wagmi'
 
 // Types
-import type { BigNumberish } from 'ethers'
+import type { BigNumber } from 'ethers'
 
 // ABIs
 import erc20Abi from '../abis/erc20.json'
@@ -18,7 +18,7 @@ export const useReputationContract = (contract?: string) => {
 
 export const useReputation = (token?: string, user?: string) => {
 	const contract = useReputationContract(token)
-	const [balance, setBalance] = useState<BigNumberish>()
+	const [balance, setBalance] = useState<BigNumber>()
 
 	useEffect(() => {
 		if (!contract || !user) {


### PR DESCRIPTION
I believe this fixes the name in the `You selected ${name} to make a deal.` box as well as the reputation for the selected user. I also removed the `location.reload()`. I think we can now remove `selectedReply`, but I'm not exactly sure where everything updates yet, so I'll need a bit more time to figure that out.

The `marketplaces/item.tsx` page is a mess though, we need to clean this up a bit! 😁 