### PR TITLE
fix: `Request` component types

### DIFF
--- a/src/pages/marketplaces/item.tsx
+++ b/src/pages/marketplaces/item.tsx
@@ -690,7 +690,6 @@ export const MarketplaceItem = () => {
 							detail
 							title={store.request.description || ''}
 							date={store.request.date}
-							repliesCount={store.request.replies.length}
 							amount={formatMoney(store.request.price ?? 0n)}
 							seeker={store.request.seeker}
 							onClickUser={(user) => navigate(`/user/${user.address}`)}

--- a/src/ui/components/request.tsx
+++ b/src/ui/components/request.tsx
@@ -5,15 +5,13 @@ import { Typography } from '../typography'
 import { formatDate, formatName } from '../utils'
 import iconReplies from '../assets/icon-replies.svg?url'
 
-interface RequestProps extends HTMLAttributes<HTMLDivElement> {
+type RequestPropsBase = HTMLAttributes<HTMLDivElement> & {
 	title: string
-	repliesCount: number
 	date: Date
 	amount: number
 	seeker: User
 	provider?: User
 	isMyListing?: boolean
-	detail?: boolean
 	onClickUser: (user: User) => void
 	status?:
 		| 'none'
@@ -25,120 +23,134 @@ interface RequestProps extends HTMLAttributes<HTMLDivElement> {
 		| 'cancelled'
 	tokenName?: string
 }
-export const Request = ({
-	title,
-	repliesCount,
-	date,
-	amount,
-	seeker,
-	provider,
-	isMyListing,
-	onClickUser,
-	detail,
-	status,
-	tokenName,
-}: RequestProps) => (
-	<div>
-		<div
-			style={{
-				display: 'flex',
-				alignItems: 'flex-start',
-				flexDirection: 'row',
-				justifyContent: 'space-between',
-			}}
-		>
-			<Typography
-				variant={detail ? 'body-extra-light-20' : 'body-extra-light-18'}
-				color="grey4"
-				style={{ flexBasis: '75%', fontSize: 20, margin: 0 }}
-			>
-				{title}
-			</Typography>
-			{!detail && (
-				<div>
-					<Typography variant="small-bold-12" color="grey4">
-						{repliesCount.toFixed()}
-					</Typography>
-					<img src={iconReplies} style={{ maxHeight: 25, maxWidth: 25 }} />
-				</div>
-			)}
-		</div>
-		<Typography variant="small-light-10" color="grey2-light-text">
-			{formatDate(date)}
-		</Typography>
-		<div
-			style={{
-				display: 'flex',
-				flexDirection: 'row',
-				justifyContent: 'space-between',
-				alignItems: 'center',
-			}}
-		>
+
+type RequestPropsConditional =
+	| {
+			detail: true
+	  }
+	| {
+			detail?: false
+			repliesCount: number
+	  }
+
+type RequestProps = RequestPropsBase & RequestPropsConditional
+
+export const Request = (props: RequestProps) => {
+	const {
+		title,
+		date,
+		amount,
+		seeker,
+		provider,
+		isMyListing,
+		onClickUser,
+		status,
+		tokenName,
+		detail,
+	} = props
+	return (
+		<div>
 			<div
-				onClick={(e) => {
-					e.stopPropagation()
-					e.preventDefault()
-					if (!isMyListing && (status === 'open' || detail) && onClickUser) {
-						onClickUser(seeker)
-					}
+				style={{
+					display: 'flex',
+					alignItems: 'flex-start',
+					flexDirection: 'row',
+					justifyContent: 'space-between',
 				}}
+			>
+				<Typography
+					variant={detail ? 'body-extra-light-20' : 'body-extra-light-18'}
+					color="grey4"
+					style={{ flexBasis: '75%', fontSize: 20, margin: 0 }}
+				>
+					{title}
+				</Typography>
+				{!detail && (
+					<div>
+						<Typography variant="small-bold-12" color="grey4">
+							{props.repliesCount.toFixed()}
+						</Typography>
+						<img src={iconReplies} style={{ maxHeight: 25, maxWidth: 25 }} />
+					</div>
+				)}
+			</div>
+			<Typography variant="small-light-10" color="grey2-light-text">
+				{formatDate(date)}
+			</Typography>
+			<div
 				style={{
 					display: 'flex',
 					flexDirection: 'row',
+					justifyContent: 'space-between',
 					alignItems: 'center',
-					cursor:
-						isMyListing || (status !== 'open' && !detail)
-							? 'default'
-							: 'pointer',
 				}}
 			>
-				<Avatar
-					avatar={seeker.avatar}
-					size={detail ? 40 : 25}
-					style={{ zIndex: 1 }}
-				/>
-				{status !== 'open' && !detail && provider && (
+				<div
+					onClick={(e) => {
+						e.stopPropagation()
+						e.preventDefault()
+						if (!isMyListing && (status === 'open' || detail) && onClickUser) {
+							onClickUser(seeker)
+						}
+					}}
+					style={{
+						display: 'flex',
+						flexDirection: 'row',
+						alignItems: 'center',
+						cursor:
+							isMyListing || (status !== 'open' && !detail)
+								? 'default'
+								: 'pointer',
+					}}
+				>
 					<Avatar
-						avatar={provider.avatar}
-						size={25}
-						style={{ marginLeft: -10, zIndex: 0 }}
+						avatar={seeker.avatar}
+						size={detail ? 40 : 25}
+						style={{ zIndex: 1 }}
 					/>
-				)}
-				{(status === 'open' || detail) && (
-					<Typography
-						variant="small-bold-12"
-						color={isMyListing ? 'grey4' : 'blue'}
-						style={{ marginLeft: 8 }}
-					>
-						<>
-							{formatName(seeker)} • {seeker.reputation.toString()} SWR
-						</>
+					{status !== 'open' && !detail && provider && (
+						<Avatar
+							avatar={provider.avatar}
+							size={25}
+							style={{ marginLeft: -10, zIndex: 0 }}
+						/>
+					)}
+					{(status === 'open' || detail) && (
+						<Typography
+							variant="small-bold-12"
+							color={isMyListing ? 'grey4' : 'blue'}
+							style={{ marginLeft: 8 }}
+						>
+							<>
+								{formatName(seeker)} • {seeker.reputation.toString()} SWR
+							</>
+						</Typography>
+					)}
+					{status !== 'open' && !detail && (
+						<Typography
+							variant="small-bold-12"
+							color="grey4"
+							style={{ marginLeft: 8 }}
+						>
+							Deal {status}.
+						</Typography>
+					)}
+				</div>
+				<div
+					style={{
+						display: 'flex',
+						flexDirection: 'column',
+						alignItems: 'flex-end',
+					}}
+				>
+					<Typography variant="small-bold-10" color="yellow">
+						{tokenName ?? 'DAI'}
 					</Typography>
-				)}
-				{status !== 'open' && !detail && (
-					<Typography
-						variant="small-bold-12"
-						color="grey4"
-						style={{ marginLeft: 8 }}
-					>
-						Deal {status}.
+					<Typography variant="header-24" color="yellow">
+						{amount}
 					</Typography>
-				)}
-			</div>
-			<div
-				style={{
-					display: 'flex',
-					flexDirection: 'column',
-					alignItems: 'flex-end',
-				}}
-			>
-				<Typography variant="small-bold-10" color="yellow">
-					{tokenName ?? 'DAI'}
-				</Typography>
-				<Typography variant="header-24" color="yellow">
-					{amount}
-				</Typography>
+				</div>
 			</div>
 		</div>
-	</div>
-)
+	)
+}


### PR DESCRIPTION
I noticed during my refactor that `repliesCount={store.request.replies.length}` was set despite it never being used. I think having more precise types could be helpful in this case.

However, it quickly becomes very difficult. I tried to do the same for the `onClickUser` condition, but didn't manage to get it to work. Also tried with generic types and `Detail extends true ? Omit<Type, 'repliesCount'> : Type` type templates, but that didn't really work either.

Honestly, I'm not sure if it's really worth it.