### PR TITLE
perf: remove `useMarketplaceItem` in `DisplayItem`

### DIFF
--- a/src/pages/marketplaces/marketplace.tsx
+++ b/src/pages/marketplaces/marketplace.tsx
@@ -8,7 +8,6 @@ import { LOGIN, MARKETPLACES, MARKETPLACE_ADD } from '../../routes'
 
 // Services
 import {
-	useMarketplaceItem,
 	useMarketplaceName,
 	useMarketplaceTokenDecimals,
 	useMarketplaceTokenName,
@@ -53,23 +52,18 @@ const DisplayItem = ({ item, decimals, marketplace }: DisplayItemProps) => {
 	const { profile } = useProfile(item.owner)
 	const avatar = useProfilePictureURL(profile?.pictureHash)
 
-	const chainItem = useMarketplaceItem(marketplace, item.id.toBigInt())
-
-	const providerProfile = useProfile(chainItem.item?.providerAddress)
+	const providerProfile = useProfile(item?.provider)
 	const providerAvatar = useProfilePictureURL(
 		providerProfile.profile?.pictureHash
 	)
-	const provider: User | undefined =
-		chainItem.item?.providerAddress &&
-		chainItem.item.providerAddress !==
-			'0x0000000000000000000000000000000000000000'
-			? {
-					address: chainItem.item.providerAddress,
-					reputation: chainItem.item?.providerRep ?? 0n,
-					name: providerProfile.profile?.username,
-					avatar: providerAvatar,
-			  }
-			: undefined
+	const provider: User | undefined = item.provider
+		? {
+				address: item.provider,
+				reputation: 0n, // not used
+				name: providerProfile.profile?.username,
+				avatar: providerAvatar,
+		  }
+		: undefined
 
 	return (
 		<div


### PR DESCRIPTION
The issue with this is simple: we're doing one JSON RPC request per displayed item, which clearly doesn't scale. As we don't display the reputation there, we actually already have all the information we need, so I was able to make that call redundant, making the app faster and the RPC happier (it doesn't constantly return `429` errors now).