### PR TITLE
fix: initial profile sync

### DIFF
--- a/src/protos/profile.proto
+++ b/src/protos/profile.proto
@@ -3,7 +3,7 @@ syntax = "proto3";
 message Profile {
   bytes address = 1;
   string username = 2;
-  optional bytes pictureHash = 3;
+  bytes pictureHash = 3;
   string date = 4;
   bytes signature = 99;
 }

--- a/src/services/waku.ts
+++ b/src/services/waku.ts
@@ -202,7 +202,10 @@ export const useLatestTopicData = <Data>(
 export const fetchLatestTopicData = <Msg extends Message>(
 	waku: WakuLight,
 	decoders: Decoder<Msg>[],
-	callback: (message: Promise<Msg | undefined>) => Promise<boolean | void>,
+	callback: <Done extends boolean>(
+		message: Done extends true ? Promise<undefined> : Promise<Msg | undefined>,
+		done?: Done
+	) => Promise<boolean | void>,
 	options?: QueryOptions | undefined,
 	watch = false
 ) => {
@@ -220,6 +223,8 @@ export const fetchLatestTopicData = <Msg extends Message>(
 				}
 			}
 		}
+
+		callback(Promise.resolve(undefined), true)
 	})()
 
 	const unsubscribe =


### PR DESCRIPTION
### Current state
The current version has issues for the initial profile sync:

1) It doesn't work when the user didn't select a profile picture
2) It asks for the password over and over again because of the profile picture cache

This solution is admittedly quite hacky, but given the demo, I won't be able to get something better out in time.

### New state
When a new user is created, the profile is uploaded correctly and the password prompt only appears once. However, the profile (and thus profile picture) of the logged-in user isn't displayed correctly (only the fallback address is displayed) until the next refresh.